### PR TITLE
DAO468 & DAO469: depositAndDelegate & transferAndDelegate functions with tests

### DIFF
--- a/contracts/StRIFToken.sol
+++ b/contracts/StRIFToken.sol
@@ -34,6 +34,58 @@ contract StRIFToken is
     __UUPSUpgradeable_init();
   }
 
+  /**
+   * @dev Allows token holder to transfer tokens to another account, after which
+   * the recipient automatically delegates votes to themselves if they do
+   * not already have a delegate.
+   * Transfer and delegation happen within one transaction.
+   * @param to The address of the recipient of the token transfer
+   * @param value The amount of tokens being transferred
+   */
+  function transferAndDelegate(address to, uint256 value) public virtual {
+    transfer(to, value);
+    _autoDelegate(to, value);
+  }
+
+  /**
+   * @dev Allows a token holder to transfer tokens from one account to another account,
+   * after which the recipient automatically delegates votes to themselves if they do
+   * not already have a delegate. This function is analogous to `transferAndDelegate` and
+   * exists as a counterpart to the `transferFrom` function from the ERC-20 standard.
+   *
+   * @param from The address of the account to transfer tokens from
+   * @param to The address of the recipient of the token transfer
+   * @param value The amount of tokens being transferred
+   */
+  function transferFromAndDelegate(address from, address to, uint256 value) public virtual {
+    transferFrom(from, to, value);
+    _autoDelegate(to, value);
+  }
+
+  /**
+   * @dev Allows to mint stRIFs from underlying RIF tokens (stake)
+   * and delegate gained voting power to a provided address
+   * @param to a target address for minting and delegation
+   * @param value amount of RIF tokens to stake
+   */
+  function depositAndDelegate(address to, uint256 value) public virtual {
+    depositFor(to, value);
+    _autoDelegate(to, value);
+  }
+
+  /**
+   * @dev Internal function to automatically delegate votes to the recipient
+   * after a token transfer, if the recipient does not already have a delegate.
+   * Delegation only occurs if the transfer amount is greater than zero.
+   *
+   * @param to The address of the recipient of the token transfer.
+   * @param value The amount of tokens being transferred.
+   */
+  function _autoDelegate(address to, uint256 value) internal virtual {
+    if (value == 0 || delegates(to) != address(0)) return;
+    _delegate(to, to);
+  }
+
   // The following functions are overrides required by Solidity.
 
   //solhint-disable-next-line no-empty-blocks

--- a/test/StRIFToken.depositAndDelegate.test.ts
+++ b/test/StRIFToken.depositAndDelegate.test.ts
@@ -1,0 +1,145 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { RIFToken, StRIFToken } from '../typechain-types'
+import { ContractTransactionResponse, parseEther } from 'ethers'
+import { deployContracts } from './deployContracts'
+
+describe('stRIF token: Function depositAndDelegate', () => {
+  let deployer: SignerWithAddress
+  let alice: SignerWithAddress
+  let bob: SignerWithAddress
+  let rif: RIFToken
+  let stRif: StRIFToken
+  let stRifAddress: string
+  let mintDelegateTx: ContractTransactionResponse
+  const votingPower = parseEther('100') // 100 RIF tokens
+
+  before(async () => {
+    /* 
+    Deployment of RIF token and transferring a certain amount to Alice.
+    See the relevant cases in StRIFToken tests
+    */
+    ;[deployer, alice, bob] = await ethers.getSigners()
+    ;({ rif, stRif, stRifAddress } = await deployContracts(deployer))
+    await (await rif.transfer(alice.address, votingPower)).wait()
+  })
+
+  describe('Approving RIFs', () => {
+    it('Alice should own 100 RIF tokens', async () => {
+      const rifBalance = await rif.balanceOf(alice.address)
+      expect(rifBalance).to.equal(votingPower)
+    })
+
+    it('Alice should set allowance for stRif contract to spend her RIFs', async () => {
+      const tx = await rif.connect(alice).approve(stRifAddress, votingPower)
+      await expect(tx).to.emit(rif, 'Approval').withArgs(alice, stRifAddress, votingPower)
+    })
+  })
+
+  describe('Before stRif minting / delegation', () => {
+    it('approval should be set on RIF', async () => {
+      expect(await rif.allowance(alice.address, stRifAddress)).to.equal(votingPower)
+    })
+
+    it('Alice should NOT have any stRIF tokens on her balance', async () => {
+      expect(await stRif.balanceOf(alice.address)).to.equal(0n)
+    })
+
+    it('Alice should NOT have delegate set', async () => {
+      expect(await stRif.delegates(alice.address)).to.equal(ethers.ZeroAddress)
+    })
+
+    it('Alice should NOT have voting power', async () => {
+      expect(await stRif.getVotes(alice.address)).to.equal(0n)
+    })
+
+    it('Alice should NOT have checkpoints', async () => {
+      expect(await stRif.numCheckpoints(alice.address)).to.equal(0n)
+    })
+  })
+
+  describe('Minting / delegation in one Tx', () => {
+    describe('Sad path', () => {
+      it('Bob should not be able to mint stRifs because he has no RIFs', async () => {
+        const tx = stRif.connect(bob).depositAndDelegate(bob.address, votingPower)
+        await expect(tx)
+          // proxy error
+          .to.be.revertedWithCustomError(stRif, 'FailedInnerCall')
+      })
+
+      it('Alice should not mint more stRifs than her RIF balance', async () => {
+        const tx = stRif.connect(alice).depositAndDelegate(alice.address, votingPower + 1n)
+        // proxy error
+        await expect(tx).to.be.revertedWithCustomError(stRif, 'FailedInnerCall')
+      })
+
+      it('Alice should not mint zero stRifs', async () => {
+        const tx = stRif.connect(alice).depositAndDelegate(alice.address, 0)
+        await expect(() => tx).to.changeTokenBalance(stRif, alice, 0)
+      })
+
+      it('Alice should not mint to zero address', async () => {
+        const tx = stRif.connect(alice).depositAndDelegate(ethers.ZeroAddress, votingPower)
+        await expect(tx)
+          .to.be.revertedWithCustomError(stRif, 'ERC20InvalidReceiver')
+          .withArgs(ethers.ZeroAddress)
+      })
+
+      it('Alice should not mint to stRif contract address', async () => {
+        const tx = stRif.connect(alice).depositAndDelegate(stRifAddress, votingPower)
+        await expect(tx).to.be.revertedWithCustomError(stRif, 'ERC20InvalidReceiver').withArgs(stRifAddress)
+      })
+    })
+
+    describe('Happy path', () => {
+      before(async () => {
+        mintDelegateTx = await stRif.connect(alice).depositAndDelegate(alice.address, votingPower)
+      })
+
+      it('Alice should stake her RIFs and mint stRIFs', async () => {
+        await expect(mintDelegateTx)
+          .to.emit(stRif, 'Transfer')
+          .withArgs(ethers.ZeroAddress, alice.address, votingPower)
+      })
+
+      it('Alice should delegate voting power in the SAME transaction', async () => {
+        await expect(mintDelegateTx)
+          .to.emit(stRif, 'DelegateChanged')
+          .withArgs(alice.address, ethers.ZeroAddress, alice.address)
+      })
+    })
+  })
+
+  describe('After minting / delegation', () => {
+    it('approval(allowance) for stRif should NO LONGER be set on RIF', async () => {
+      expect(await rif.allowance(alice.address, stRifAddress)).to.equal(0n)
+    })
+
+    it('Alice should have newly minted stRIF tokens on her balance', async () => {
+      expect(await stRif.balanceOf(alice.address)).to.equal(votingPower)
+    })
+
+    it('Alice should now be the delegate of herself', async () => {
+      expect(await stRif.delegates(alice.address)).to.equal(alice.address)
+    })
+
+    it('Alice should have voting power', async () => {
+      expect(await stRif.getVotes(alice.address)).to.equal(votingPower)
+    })
+
+    it('Alice should have 1 checkpoint', async () => {
+      expect(await stRif.numCheckpoints(alice.address)).to.equal(1n)
+    })
+
+    it('block number and voting power should be recorded (snapshot) at the checkpoint', async () => {
+      const checkpointIndex = 0n
+      const [blockNumAtCheckpoint, votePowerAtCheckpoint] = await stRif.checkpoints(
+        alice.address,
+        checkpointIndex,
+      )
+      expect(blockNumAtCheckpoint).to.equal(mintDelegateTx.blockNumber)
+      expect(votePowerAtCheckpoint).to.equal(votingPower)
+    })
+  })
+})

--- a/test/StRIFToken.transferAndDelegate.test.ts
+++ b/test/StRIFToken.transferAndDelegate.test.ts
@@ -1,0 +1,167 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { RIFToken, StRIFToken } from '../typechain-types'
+import { ContractTransactionResponse, parseEther } from 'ethers'
+import { deployContracts } from './deployContracts'
+
+describe('stRIF token: Function transferAndDelegate', () => {
+  let deployer: SignerWithAddress
+  let alice: SignerWithAddress
+  let bob: SignerWithAddress
+  let john: SignerWithAddress
+  let rif: RIFToken
+  let stRif: StRIFToken
+  let transferAndDelegateTx: ContractTransactionResponse
+  const votingPower = parseEther('100') // RIF tokens
+
+  const enfranchiseUser = async (user: SignerWithAddress, amount: bigint) => {
+    await (await rif.transfer(user.address, amount)).wait()
+    await (await rif.connect(user).approve(await stRif.getAddress(), amount)).wait()
+    await (await stRif.connect(user).depositAndDelegate(user.address, amount)).wait()
+  }
+
+  before(async () => {
+    ;[deployer, alice, bob, john] = await ethers.getSigners()
+    ;({ rif, stRif } = await deployContracts(deployer))
+    await enfranchiseUser(alice, votingPower)
+    await enfranchiseUser(john, votingPower)
+  })
+
+  describe('Before transfer', () => {
+    it('Alice should own 100 stRIFs tokens', async () => {
+      expect(await stRif.balanceOf(alice.address)).to.equal(votingPower)
+    })
+    it('Bob should not have stRIFs tokens', async () => {
+      expect(await stRif.balanceOf(alice.address)).to.equal(votingPower)
+    })
+    it('Alice should be her own delegate', async () => {
+      expect(await stRif.delegates(alice.address)).to.equal(alice.address)
+    })
+    it('Bob shouldn`t have delegates', async () => {
+      expect(await stRif.delegates(bob.address)).to.equal(ethers.ZeroAddress)
+    })
+    it('Alice should have voting power', async () => {
+      expect(await stRif.getVotes(alice.address)).to.equal(votingPower)
+    })
+    it('Bob shouldn`t have voting power', async () => {
+      expect(await stRif.getVotes(bob.address)).to.equal(0n)
+    })
+  })
+
+  describe('Transfer and delegate', () => {
+    describe('Sad path', () => {
+      it('should not change balances after transfer of zero tokens', async () => {
+        const tx = await stRif.connect(alice).transferAndDelegate(bob.address, 0n)
+        await expect(() => tx).to.changeTokenBalances(stRif, [alice, bob], [0n, 0n])
+      })
+      it('Bob should`t be delegated to vote after transfer of 0 tokens', async () => {
+        expect(await stRif.delegates(bob.address)).to.equal(ethers.ZeroAddress)
+      })
+      it('Alice shouldn`t be able to transfer and delegate to zero address', async () => {
+        const tx = stRif.connect(alice).transferAndDelegate(ethers.ZeroAddress, votingPower)
+        await expect(tx)
+          .to.be.revertedWithCustomError(stRif, 'ERC20InvalidReceiver')
+          .withArgs(ethers.ZeroAddress)
+      })
+    })
+    describe('Happy path', () => {
+      before(async () => {
+        transferAndDelegateTx = await stRif.connect(alice).transferAndDelegate(bob.address, parseEther('25'))
+      })
+      it('Alice should use `transferAndDelegate` function to transfer 1/4 tokens to Bob', async () => {
+        await expect(transferAndDelegateTx)
+          .to.emit(stRif, 'Transfer')
+          .withArgs(alice.address, bob.address, parseEther('25'))
+      })
+      it('Voting power should be delegated to Bob within the SAME transaction', async () => {
+        await expect(transferAndDelegateTx)
+          .to.emit(stRif, 'DelegateChanged')
+          .withArgs(bob.address, ethers.ZeroAddress, bob.address)
+      })
+    })
+  })
+
+  describe('After transfer', () => {
+    it('Alice should own 3/4 tokens', async () => {
+      expect(await stRif.balanceOf(alice.address)).to.equal(parseEther('75'))
+    })
+    it('Bob should own 1/4 tokens', async () => {
+      expect(await stRif.balanceOf(bob.address)).to.equal(parseEther('25'))
+    })
+    it('Alice should STILL be her own delegate', async () => {
+      expect(await stRif.delegates(alice.address)).to.equal(alice.address)
+    })
+    it('Bob should be his own delegate (the delegation was from Bob to Bob)', async () => {
+      expect(await stRif.delegates(bob.address)).to.equal(bob.address)
+    })
+    it('Alice`s voting power should equal her balance (3/4)', async () => {
+      expect(await stRif.getVotes(alice.address)).to.equal(parseEther('75'))
+    })
+    it('Bob`s voting power should equal his balance (1/4)', async () => {
+      expect(await stRif.getVotes(bob.address)).to.equal(parseEther('25'))
+    })
+  })
+
+  describe('Receiving tokens from a third source after the delegation', () => {
+    let johnsTransferTx: ContractTransactionResponse
+
+    it('John should own 100 stRIFs tokens', async () => {
+      expect(await stRif.balanceOf(john.address)).to.equal(votingPower)
+    })
+    it('John should transfer his tokens to Bob', async () => {
+      johnsTransferTx = await stRif.connect(john).transferAndDelegate(bob.address, votingPower)
+      await expect(() => johnsTransferTx).to.changeTokenBalances(
+        stRif,
+        [john, bob],
+        [-votingPower, votingPower],
+      )
+    })
+    it('John`s transfer tx should NOT initiate another delegation', async () => {
+      await expect(johnsTransferTx).not.to.emit(stRif, 'DelegateChanged')
+    })
+    it('Bob should remain his own delegate', async () => {
+      expect(await stRif.delegates(bob.address)).to.equal(bob.address)
+    })
+    it('Bob`s voting power should include Alice`s and John`s tokens', async () => {
+      expect(await stRif.getVotes(bob.address)).to.equal(parseEther('25') + votingPower)
+    })
+  })
+
+  describe('transferFromAndDelegate: a variation with approval', () => {
+    const amount = parseEther('25')
+    let transferTx: ContractTransactionResponse
+
+    it('should reset Bob`s delegate back to zero address', async () => {
+      const tx = await stRif.connect(bob).delegate(ethers.ZeroAddress)
+      await expect(tx)
+        .to.emit(stRif, 'DelegateChanged')
+        .withArgs(bob.address, bob.address, ethers.ZeroAddress)
+    })
+    it('Bob should no longer have delegate', async () => {
+      expect(await stRif.delegates(bob.address)).to.equal(ethers.ZeroAddress)
+    })
+    it('Alice should approve Bob to transfer 25 stRIFs', async () => {
+      const tx = await stRif.connect(alice).approve(bob.address, amount)
+      await expect(tx).to.emit(stRif, 'Approval').withArgs(alice.address, bob.address, amount)
+    })
+    it('Bob now has approval to transfer stRIFs from Alice`s balance', async () => {
+      expect(await stRif.allowance(alice.address, bob.address)).to.equal(amount)
+    })
+    it('Bob should transfer Alice`s stRIFs to himself ', async () => {
+      transferTx = await stRif.connect(bob).transferFromAndDelegate(alice.address, bob.address, amount)
+      await expect(() => transferTx).to.changeTokenBalances(stRif, [bob, alice], [amount, -amount])
+    })
+    it('Bob`s tx should emit Transfer event', async () => {
+      await expect(transferTx).to.emit(stRif, 'Transfer').withArgs(alice.address, bob.address, amount)
+    })
+    it('Bob should become his own delegate within the same tx', async () => {
+      await expect(transferTx)
+        .to.emit(stRif, 'DelegateChanged')
+        .withArgs(bob.address, ethers.ZeroAddress, bob.address)
+    })
+    it('Bob should be his own delegate', async () => {
+      expect(await stRif.delegates(bob.address)).to.equal(bob.address)
+    })
+  })
+})

--- a/test/deployContracts.ts
+++ b/test/deployContracts.ts
@@ -1,0 +1,15 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
+import { ethers } from 'hardhat'
+import { deployStRIF } from '../scripts/deploy-stRIF'
+
+export const deployContracts = async (admin: SignerWithAddress) => {
+  const rif = await (await ethers.deployContract('RIFToken', { signer: admin })).waitForDeployment()
+  const rifAddress = await rif.getAddress()
+  await (await rif.setAuthorizedManagerContract(admin.address)).wait()
+  const latestBlock = await ethers.provider.getBlock('latest')
+  if (!latestBlock) throw new Error('Latest block not found')
+  await (await rif.closeTokenDistribution(latestBlock.timestamp)).wait()
+  const stRif = await deployStRIF(rifAddress, admin.address)
+  const stRifAddress = await stRif.getAddress()
+  return { rif, rifAddress, stRif, stRifAddress }
+}


### PR DESCRIPTION
# What 

- in `stRIF` smart contract create 3 new public functions:
  - `depositAndDelegate`: to stake RIFs to stRIFs + delegate to same address in one tx
  - `transferAndDelegate`: to transfer stRifs to another account + delegate to same address in one tx
  - `transferFromAndDelegate`: the same thing including prior approval
- write test cases for happy \ unhappy paths
- all tests are passing
- slither doesnt find any issues

# Why

This functions will allow users to stake/transfer and delegate within a single transaction

# Ref

[DAO-468](https://rsklabs.atlassian.net/browse/DAO-468)
[DAO-469](https://rsklabs.atlassian.net/browse/DAO-469)

# Comment

Sorry for 2 tickets within one PR, but all functions are very closely tied together and can hardly be separated