### PR TITLE
fix: governor parameters

### DIFF
--- a/contracts/Governor.sol
+++ b/contracts/Governor.sol
@@ -35,7 +35,7 @@ contract RootDao is
         address initialOwner
     ) public initializer {
         __Governor_init("RootDao");
-        __GovernorSettings_init(1 /* 1 block */, 60 /* 30 minutes */, 10 * 10 ** 18);
+        __GovernorSettings_init(1 /* 1 block */, 240 /* 2 hours */, 10 * 10 ** 18);
         __GovernorCountingSimple_init();
         __GovernorStorage_init();
         __GovernorVotes_init(voteToken);

--- a/ignition/modules/TimelockModule.ts
+++ b/ignition/modules/TimelockModule.ts
@@ -9,7 +9,7 @@ export const timelockProxyModule = buildModule('TimelockProxy', m => {
       executors: accounts to be granted executor role
       admin: optional account to be granted admin role; disable with zero address
   */
-  const minDelay = m.getParameter('minDelay', 60 * 60 * 24) // 24 hours in seconds
+  const minDelay = m.getParameter('minDelay', 60 * 15) // 15 minutes in seconds
   const proposers: string[] = []
   const executors: string[] = []
   const admin = m.getAccount(0)

--- a/test/Governor.test.ts
+++ b/test/Governor.test.ts
@@ -9,7 +9,7 @@ import { deployContracts } from './deployContracts'
 
 describe('RootDAO Contact', () => {
   const initialVotingDelay = 1n
-  const initialVotingPeriod = 60n
+  const initialVotingPeriod = 240n // 2 hours
   const initialProposalThreshold = 10n * 10n ** 18n
 
   let rif: RIFToken


### PR DESCRIPTION
# What

Change proposal parameters:
- voting period from 60 minutes to 2 hours
- timelock delay from 1 day to 15 minutes

# Why

For dapp testing convenience. 

# Ref

[The ticket](https://rsklabs.atlassian.net/browse/DAO-517) says 
| 12 hour vote, 1 hour delay
but we agreed that it should be even shorted

# Note

The contracts will need to be redeployed after these changes