### PR TITLE
Change the name of the contract

### DIFF
--- a/contracts/Governor.sol
+++ b/contracts/Governor.sol
@@ -13,7 +13,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-contract RootDao is
+contract Governor is
   Initializable,
   GovernorUpgradeable,
   GovernorSettingsUpgradeable,
@@ -41,7 +41,7 @@ contract RootDao is
     TimelockControllerUpgradeable timelockController,
     address initialOwner
   ) public initializer {
-    __Governor_init("RootDao");
+    __Governor_init("RootstockCollective");
     __GovernorSettings_init(1 /* 1 block */, 240 /* 2 hours */, 10 * 10 ** 18);
     __GovernorCountingSimple_init();
     __GovernorStorage_init();

--- a/ignition/modules/GovernorModule.ts
+++ b/ignition/modules/GovernorModule.ts
@@ -5,7 +5,7 @@ import StRifModule from './StRifModule'
 export const governorProxyModule = buildModule('GovernorProxy', m => {
   const deployer = m.getAccount(0)
   // deploy implementation
-  const governor = m.contract('RootDao')
+  const governor = m.contract('Governor')
   // deploy ERC1967 proxy in order to use UUPS upgradable smart contracts
   const { timelock } = m.useModule(TimelockModule)
   const { stRif } = m.useModule(StRifModule)
@@ -20,7 +20,7 @@ const governorModule = buildModule('Governor', m => {
   const deployer = m.getAccount(0)
   const { governorProxy, timelock, stRif } = m.useModule(governorProxyModule)
   // Use proxy address to interact with the deployed contract
-  const governor = m.contractAt('RootDao', governorProxy)
+  const governor = m.contractAt('Governor', governorProxy)
 
   // grant Proposer role to the Governor
   const proposerRole = m.staticCall(timelock, 'PROPOSER_ROLE')

--- a/test/Governor.test.ts
+++ b/test/Governor.test.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
 import { loadFixture, mine, time } from '@nomicfoundation/hardhat-toolbox/network-helpers'
-import { RIFToken, RootDao, StRIFToken, DaoTimelockUpgradable, ProposalTarget } from '../typechain-types'
+import { RIFToken, Governor, StRIFToken, DaoTimelockUpgradable, ProposalTarget } from '../typechain-types'
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
 import { ContractTransactionResponse, parseEther, solidityPackedKeccak256 } from 'ethers'
 import { Proposal, ProposalState, OperationState } from '../types'
 import { deployContracts } from './deployContracts'
 
-describe('RootDAO Contact', () => {
+describe('Governor Contact', () => {
   const initialVotingDelay = 1n
   const initialVotingPeriod = 240n // 2 hours
   const initialProposalThreshold = 10n * 10n ** 18n
@@ -17,7 +17,7 @@ describe('RootDAO Contact', () => {
   let rifAddress: string
   let stRIF: StRIFToken
   let timelock: DaoTimelockUpgradable
-  let governor: RootDao
+  let governor: Governor
   let proposalTarget: ProposalTarget
   let holders: SignerWithAddress[]
 

--- a/test/deployContracts.ts
+++ b/test/deployContracts.ts
@@ -1,5 +1,5 @@
 import { ignition } from 'hardhat'
-import { RIFToken, StRIFToken, DaoTimelockUpgradable, RootDao, TreasuryDao } from '../typechain-types'
+import { RIFToken, StRIFToken, DaoTimelockUpgradable, Governor, TreasuryDao } from '../typechain-types'
 import RifModule from '../ignition/modules/RifModule'
 import GovernorModule from '../ignition/modules/GovernorModule'
 import TreasuryModule from '../ignition/modules/TreasuryModule'
@@ -21,7 +21,7 @@ export const deployContracts = async () => {
     rif: rif as unknown as RIFToken,
     stRIF: dao.stRif as unknown as StRIFToken,
     timelock: dao.timelock as unknown as DaoTimelockUpgradable,
-    governor: dao.governor as unknown as RootDao,
+    governor: dao.governor as unknown as Governor,
     treasury: treasury as unknown as TreasuryDao,
   }
 }


### PR DESCRIPTION
Changes the name of the contract to match the filename `Governor` and then sets the Name property to RootstockCollective. 