### PR TITLE
Nft restrictions

### DIFF
--- a/ignition/eaNft.json
+++ b/ignition/eaNft.json
@@ -3,6 +3,8 @@
     "defaultAdmin": "0xb42c26BB804987EE7FEFb897eB18ED775da19Fe4",
     "upgrader": "0xb42c26BB804987EE7FEFb897eB18ED775da19Fe4",
     "numFiles": 100,
-    "ipfs": "QmQjqoXjWwLA2iukbmJyM88xvcP28Fi9Mp8CrNaCDha9Dg"
+    "ipfs": "QmQjqoXjWwLA2iukbmJyM88xvcP28Fi9Mp8CrNaCDha9Dg",
+    "stRif": "0xd6Eb12591559C42e28d672197265b331B1ad867d",
+    "stRifThreshold": "100000000000000000000"
   }
 }

--- a/ignition/modules/EarlyAdoptersModule.ts
+++ b/ignition/modules/EarlyAdoptersModule.ts
@@ -9,9 +9,11 @@ export const earlyAdoptersProxyModule = buildModule('EarlyAdoptersProxy', m => {
   const upgrader = m.getParameter('upgrader', deployer)
   const numFiles = m.getParameter('numFiles')
   const ipfs = m.getParameter('ipfs')
+  const stRif = m.getParameter('stRif')
+  const stRifThreshold = m.getParameter('stRifThreshold')
   const eaProxy = m.contract('ERC1967Proxy', [
     ea,
-    m.encodeFunctionCall(ea, 'initialize', [defaultAdmin, upgrader, numFiles, ipfs]),
+    m.encodeFunctionCall(ea, 'initialize', [defaultAdmin, upgrader, stRif, stRifThreshold, numFiles, ipfs]),
   ])
   return { eaProxy }
 })

--- a/test/EarlyAdopters.test.ts
+++ b/test/EarlyAdopters.test.ts
@@ -17,6 +17,7 @@ describe('Early Adopters', () => {
   let deployer: SignerWithAddress
   let alice: SignerWithAddress
   let bob: SignerWithAddress
+  let mike: SignerWithAddress
 
   const firstNftId = 1
 
@@ -29,7 +30,7 @@ describe('Early Adopters', () => {
   }
 
   before(async () => {
-    ;;[deployer, alice, bob] = await ethers.getSigners()
+    ;[deployer, alice, bob, mike] = await ethers.getSigners()
     ;({ ea, rif, stRIF } = await deployContracts(initialNftSupply, ipfsCid, stRifThreshold))
     eaAddress = await ea.getAddress()
     await sendStRifsTo(deployer, alice, bob)
@@ -71,7 +72,7 @@ describe('Early Adopters', () => {
       expect(await ea.totalSupply()).to.equal(0)
     })
 
-    it('deployer, Alice and Bob should should have enough stRIFs', async () => {
+    it('deployer, Alice and Bob should should have enough stRIFs for minting NFTs', async () => {
       await Promise.all(
         [deployer, alice, bob].map(async owner => {
           expect(await stRIF.balanceOf(owner.address)).to.equal(stRifThreshold)
@@ -81,6 +82,11 @@ describe('Early Adopters', () => {
   })
 
   describe('Join Early Adopters community / Minting NFTs', () => {
+    it('Mike cannot mint an NFT because he doesn`t own enough StRIFs', async () => {
+      await expect(ea.connect(mike).mint())
+        .to.be.revertedWithCustomError(ea, 'BelowStRifThreshold')
+        .withArgs(0, stRifThreshold)
+    })
     it('Alice should join the EA community by minting an Nft', async () => {
       const mintTx = await ea.connect(alice).mint()
       await expect(mintTx).to.emit(ea, 'Transfer').withArgs(ethers.ZeroAddress, alice.address, firstNftId)
@@ -114,52 +120,64 @@ describe('Early Adopters', () => {
   })
 
   describe('Transferring NFTs / changing EA membership', () => {
+    it('Alice should not be able to transfer her token during the distribution', async () => {
+      const transferTx = ea.connect(alice).transferFrom(alice.address, bob.address, firstNftId)
+      const tokensAvailable = await ea.tokensAvailable()
+      await expect(transferTx)
+        .to.be.revertedWithCustomError(ea, 'DistributionActive')
+        .withArgs(tokensAvailable)
+    })
+
+    it('Should close distribution by minting 2 more tokens', async () => {
+      await Promise.all(
+        [deployer, bob].map(async (signer, i) => {
+          await expect(ea.connect(signer).mint())
+            .to.emit(ea, 'Transfer')
+            .withArgs(ethers.ZeroAddress, signer.address, i + 2)
+        }),
+      )
+      expect(await ea.tokensAvailable()).to.equal(0)
+    })
+
+    it('the number of members in the EA community should increase by 2', async () => {
+      expect(await ea.totalSupply()).to.equal(3)
+    })
+
     it('Alice should not be able to transfer her token to zero address', async () => {
       const transferTx = ea.connect(alice).transferFrom(alice.address, ethers.ZeroAddress, firstNftId)
       await expect(transferTx).to.be.reverted
     })
 
-    it('Alice should transfer her token to Bob', async () => {
-      const transferTx = ea.connect(alice).transferFrom(alice.address, bob.address, firstNftId)
-      await expect(transferTx).to.emit(ea, 'Transfer').withArgs(alice.address, bob.address, firstNftId)
+    it('Alice should transfer her token to Mike', async () => {
+      const transferTx = ea.connect(alice).transferFrom(alice.address, mike.address, firstNftId)
+      await expect(transferTx).to.emit(ea, 'Transfer').withArgs(alice.address, mike.address, firstNftId)
     })
 
     it('Alice should no longer be a member of EA community', async () => {
       expect(await ea.balanceOf(alice.address)).to.equal(0)
     })
 
-    it('Bob should now be a member of EA community', async () => {
-      expect(await ea.balanceOf(bob.address)).to.equal(1)
+    it('Mike should now be a member of EA community', async () => {
+      expect(await ea.balanceOf(mike.address)).to.equal(1)
     })
 
-    it('Bob should now be the owner of the first NFT', async () => {
-      expect(await ea.ownerOf(firstNftId)).to.equal(bob.address)
+    it('Mike should now be the owner of the first NFT', async () => {
+      expect(await ea.ownerOf(firstNftId)).to.equal(mike.address)
     })
 
-    it('Bob should read his token URI by providing his account address', async () => {
-      expect(await ea.tokenUriByOwner(bob.address)).to.equal(nftUri(firstNftId))
+    it('Mike should read his token URI by providing his account address', async () => {
+      expect(await ea.tokenUriByOwner(mike.address)).to.equal(nftUri(firstNftId))
     })
 
     it('the number of members in the EA community should not change', async () => {
-      expect(await ea.totalSupply()).to.equal(1)
+      expect(await ea.totalSupply()).to.equal(3)
     })
 
     it('Deployer should not be able to transfer his ownership to Bob because Bob is already a member', async () => {
-      await (await ea.connect(deployer).mint()).wait()
       expect(await ea.ownerOf(firstNftId + 1)).to.equal(deployer.address)
       await expect(ea.transferFrom(deployer.address, bob.address, firstNftId + 1))
         .to.be.revertedWithCustomError(ea, 'ERC721InvalidOwner')
         .withArgs(bob.address)
-    })
-
-    it('Alice should be able to join the EA community once again and get a new NFT instead of transferred one', async () => {
-      await expect(await ea.connect(alice).mint())
-        .to.emit(ea, 'Transfer')
-        .withArgs(ethers.ZeroAddress, alice.address, firstNftId + 2)
-    })
-
-    it('the number of members in the EA community should increase by 2', async () => {
-      expect(await ea.totalSupply()).to.equal(3)
     })
   })
 
@@ -193,7 +211,7 @@ describe('Early Adopters', () => {
     })
 
     it('should not be possible to mint more tokens', async () => {
-      await expect(ea.connect(bob).mint())
+      await expect(ea.connect(alice).mint())
         .to.be.revertedWithCustomError(ea, 'OutOfTokens')
         .withArgs(initialNftSupply)
     })
@@ -214,22 +232,22 @@ describe('Early Adopters', () => {
       expect(await ea.tokensAvailable()).to.equal(newSupply - initialNftSupply)
     })
 
-    it('should be possible to mint more tokens after topping up the max supply', async () => {
-      await expect(ea.connect(bob).mint())
+    it('Alice should be able to join the EA community again after topping up the max supply', async () => {
+      await expect(await ea.connect(alice).mint())
         .to.emit(ea, 'Transfer')
-        .withArgs(ethers.ZeroAddress, bob.address, 4)
+        .withArgs(ethers.ZeroAddress, alice.address, 4)
     })
 
     it('should increase the number of members in the EA by 1', async () => {
       expect(await ea.totalSupply()).to.equal(3)
     })
 
-    it('Alice should have the same token ID after the folder change', async () => {
-      expect(await ea.tokenIdByOwner(alice.address)).to.equal(3)
+    it('Deployer should have the same token ID after the folder change', async () => {
+      expect(await ea.tokenIdByOwner(deployer.address)).to.equal(2)
     })
 
-    it(`Alice's NFT should change URI after the IPFS directory change`, async () => {
-      expect(await ea.tokenUriByOwner(alice.address)).to.equal(nftUri(3, newIpfs))
+    it(`Deployer's NFT should change URI after the IPFS directory change`, async () => {
+      expect(await ea.tokenUriByOwner(deployer.address)).to.equal(nftUri(2, newIpfs))
     })
   })
 })

--- a/test/EarlyAdopters.test.ts
+++ b/test/EarlyAdopters.test.ts
@@ -31,7 +31,7 @@ describe('Early Adopters', () => {
   }
 
   before(async () => {
-    ;;[deployer, alice, bob, mike] = await ethers.getSigners()
+    ;[deployer, alice, bob, mike] = await ethers.getSigners()
     ;({ rif, stRIF } = await loadFixture(deployContracts))
     ea = await deployNFT(ipfsCid, initialNftSupply, await stRIF.getAddress(), stRifThreshold)
     eaAddress = await ea.getAddress()
@@ -58,6 +58,12 @@ describe('Early Adopters', () => {
       expect(await ea.balanceOf(deployer.address)).to.equal(0)
       expect(await ea.balanceOf(alice.address)).to.equal(0)
       expect(await ea.balanceOf(bob.address)).to.equal(0)
+    })
+
+    it('deployer, Alice and Bob should not be members of the community', async () => {
+      expect(await ea.isMember(deployer.address)).to.be.false
+      expect(await ea.isMember(alice.address)).to.be.false
+      expect(await ea.isMember(bob.address)).to.be.false
     })
 
     it('deployer, Alice and Bob should should have no token URIs', async () => {
@@ -102,6 +108,7 @@ describe('Early Adopters', () => {
 
     it('Alice should be a member of EA community', async () => {
       expect(await ea.balanceOf(alice.address)).to.equal(1)
+      expect(await ea.isMember(alice.address)).to.be.true
     })
 
     it('Alice should be owner of the first NFT', async () => {
@@ -136,6 +143,7 @@ describe('Early Adopters', () => {
           await expect(ea.connect(signer).mint())
             .to.emit(ea, 'Transfer')
             .withArgs(ethers.ZeroAddress, signer.address, i + 2)
+          expect(await ea.isMember(signer.address)).to.be.true
         }),
       )
       expect(await ea.tokensAvailable()).to.equal(0)
@@ -156,11 +164,11 @@ describe('Early Adopters', () => {
     })
 
     it('Alice should no longer be a member of EA community', async () => {
-      expect(await ea.balanceOf(alice.address)).to.equal(0)
+      expect(await ea.isMember(alice.address)).to.be.false
     })
 
     it('Mike should now be a member of EA community', async () => {
-      expect(await ea.balanceOf(mike.address)).to.equal(1)
+      expect(await ea.isMember(mike.address)).to.be.true
     })
 
     it('Mike should now be the owner of the first NFT', async () => {
@@ -190,7 +198,7 @@ describe('Early Adopters', () => {
     })
 
     it('Bob should no longer be a member of the community', async () => {
-      expect(await ea.balanceOf(bob.address)).to.equal(0)
+      expect(await ea.isMember(bob.address)).to.be.false
     })
 
     it('Non-member should not be able to burn', async () => {

--- a/test/deployContracts.ts
+++ b/test/deployContracts.ts
@@ -1,10 +1,18 @@
-import { ignition } from 'hardhat'
-import { RIFToken, StRIFToken, DaoTimelockUpgradable, Governor, TreasuryDao } from '../typechain-types'
+import { ignition, ethers } from 'hardhat'
+import {
+  RIFToken,
+  StRIFToken,
+  DaoTimelockUpgradable,
+  Governor,
+  TreasuryDao,
+  EarlyAdopters,
+} from '../typechain-types'
 import RifModule from '../ignition/modules/RifModule'
 import GovernorModule from '../ignition/modules/GovernorModule'
 import TreasuryModule from '../ignition/modules/TreasuryModule'
+import EarlyAdoptersModule from '../ignition/modules/EarlyAdoptersModule'
 
-export const deployContracts = async () => {
+export const deployContracts = async (maxNftSupply: number, ipfsCid: string, stRifThreshold: bigint) => {
   // deploy RIF before the rest DAO contracts
   const { rif } = await ignition.deploy(RifModule)
   // deploy Treasury
@@ -17,11 +25,26 @@ export const deployContracts = async () => {
       },
     },
   })
+  // deploy Early Adopters NFT
+  const [defaultAdmin, upgrader] = await ethers.getSigners()
+  const { ea } = await ignition.deploy(EarlyAdoptersModule, {
+    parameters: {
+      EarlyAdoptersProxy: {
+        ipfs: ipfsCid,
+        numFiles: maxNftSupply,
+        defaultAdmin: defaultAdmin.address,
+        upgrader: upgrader.address,
+        stRif: await dao.stRif.getAddress(),
+        stRifThreshold,
+      },
+    },
+  })
   return {
     rif: rif as unknown as RIFToken,
     stRIF: dao.stRif as unknown as StRIFToken,
     timelock: dao.timelock as unknown as DaoTimelockUpgradable,
     governor: dao.governor as unknown as Governor,
     treasury: treasury as unknown as TreasuryDao,
+    ea: ea as unknown as EarlyAdopters,
   }
 }


### PR DESCRIPTION
# What

Implement round 2 of NFT prevention enhancements

- Early Adopters community joiner needs to own a certain amount of StRIF tokens to mint an NFT
- It is disallowed to transfer tokens between accounts until all tokens are minted
- Add `setStRifThreshold` function for admin to be able to modify the StRIF threshold
- Add a utility function `isMember` to find out if an address is a member of the EA community 

# Why 

To make it more costly for one person to mint all the tokens 

# Ref

[DAO-650](https://rsklabs.atlassian.net/browse/DAO-650)