### PR TITLE
fix: RIF token mainnet address

### DIFF
--- a/params/mainnet.json
+++ b/params/mainnet.json
@@ -1,6 +1,6 @@
 {
   "stRifProxy": {
-    "rifAddress": "0x2aCc95758f8b5F583470bA265Eb685a8f45fC9D5",
+    "rifAddress": "0x2AcC95758f8b5F583470ba265EB685a8F45fC9D5",
     "owner": "0x479E6e9c409A56393D4b0c5749a3f09212529f90"
   },
   "GovernorProxy": {


### PR DESCRIPTION
# What

corrected letters case in RIF token mainnet address