### PR TITLE
feat: treasury executor role

### DIFF
--- a/contracts/TreasuryRootstockCollective.sol
+++ b/contracts/TreasuryRootstockCollective.sol
@@ -20,6 +20,7 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
 
   mapping(address => bool) public whitelist;
   bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
+  bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
 
   /**
    * @dev Sets the values for {initialOwner} and {guardian}
@@ -40,7 +41,8 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
   }
 
   /**
-   * @dev Withdraw an ERC20 token to a third-party address.
+   * @dev Withdraw an ERC20 token to a third-party address. This function is
+   * a target for the DAO proposals executor
    * @param token The ERC20 token
    * @param to The third-party address
    * @param amount The value to send
@@ -49,11 +51,11 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
     address token,
     address to,
     uint256 amount
-  ) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+  ) external onlyRole(EXECUTOR_ROLE) nonReentrant {
     require(whitelist[token], "Token forbidden");
     require(IERC20(token).balanceOf(address(this)) >= amount, "Insufficient ERC20 balance");
-    IERC20(token).safeTransfer(to, amount);
     emit WithdrawnERC20(token, to, amount);
+    IERC20(token).safeTransfer(to, amount);
   }
 
   /**
@@ -65,8 +67,8 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
     require(whitelist[token], "Token forbidden");
     require(to != address(0), "Zero Address is not allowed");
     uint256 amount = IERC20(token).balanceOf(address(this));
-    IERC20(token).safeTransfer(to, amount);
     emit WithdrawnERC20(token, to, amount);
+    IERC20(token).safeTransfer(to, amount);
   }
 
   /**
@@ -78,16 +80,17 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
    * such as `onlyRole`, which ensures that only authorized users
    * can execute the function, and `nonReentrant`.
    * which protects against reentrant attacks.
+   * This function is a target for the DAO proposals executor.
    * @param to The third-party address
    * @param amount The value to send
    */
   // slither-disable-next-line arbitrary-send-eth
-  function withdraw(address payable to, uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+  function withdraw(address payable to, uint256 amount) external onlyRole(EXECUTOR_ROLE) nonReentrant {
     require(address(this).balance >= amount, "Insufficient Balance");
     require(to != address(0), "Zero Address is not allowed");
+    emit Withdrawn(to, amount);
     bool success = to.send(amount);
     require(success, "Failed to sent");
-    emit Withdrawn(to, amount);
   }
 
   /**
@@ -104,9 +107,9 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
   function emergencyWithdraw(address payable to) external nonReentrant onlyRole(GUARDIAN_ROLE) {
     require(to != address(0), "Zero Address is not allowed");
     uint256 amount = address(this).balance;
+    emit Withdrawn(to, amount);
     bool success = to.send(amount);
     require(success, "Failed to sent");
-    emit Withdrawn(to, amount);
   }
 
   /**
@@ -120,10 +123,10 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
 
   /**
    * @dev Add to whitelist a new ERC20 token
-   * requires admin role
+   * requires guardian role
    * @param token ERC20 token
    */
-  function addToWhitelist(address token) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function addToWhitelist(address token) external onlyRole(GUARDIAN_ROLE) {
     _addToWhitelist(token);
   }
 
@@ -138,10 +141,10 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
 
   /**
    * @dev Remove from whitelist an ERC20 token
-   * requires admin role
+   * requires guardian role
    * @param token ERC20 token
    */
-  function removeFromWhitelist(address token) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function removeFromWhitelist(address token) external onlyRole(GUARDIAN_ROLE) {
     _removeFromWhitelist(token);
   }
 

--- a/contracts/TreasuryRootstockCollective.sol
+++ b/contracts/TreasuryRootstockCollective.sol
@@ -123,10 +123,10 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
 
   /**
    * @dev Add to whitelist a new ERC20 token
-   * requires guardian role
+   * requires executor role
    * @param token ERC20 token
    */
-  function addToWhitelist(address token) external onlyRole(GUARDIAN_ROLE) {
+  function addToWhitelist(address token) external onlyRole(EXECUTOR_ROLE) {
     _addToWhitelist(token);
   }
 
@@ -141,10 +141,10 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
 
   /**
    * @dev Remove from whitelist an ERC20 token
-   * requires guardian role
+   * requires executor role
    * @param token ERC20 token
    */
-  function removeFromWhitelist(address token) external onlyRole(GUARDIAN_ROLE) {
+  function removeFromWhitelist(address token) external onlyRole(EXECUTOR_ROLE) {
     _removeFromWhitelist(token);
   }
 

--- a/ignition/modules/TreasuryModule.ts
+++ b/ignition/modules/TreasuryModule.ts
@@ -1,13 +1,9 @@
 import { buildModule } from '@nomicfoundation/ignition-core'
 
 /**
- * Usage:
- * ```shell
- * npx hardhat ignition deploy \
- *   ignition/modules/TreasuryModule.ts \
- *   --parameters params/testnet.json \
- *   --network rootstockTestnet
- * ```
+ * Deploys Treasury contract.
+ * The Treasury is deployed along with
+ * other DAO contracts using the Governor module.
  */
 const treasuryModule = buildModule('Treasury', m => {
   const owner = m.getParameter('owner')

--- a/ignition/modules/TreasuryModule.ts
+++ b/ignition/modules/TreasuryModule.ts
@@ -10,6 +10,9 @@ const treasuryModule = buildModule('Treasury', m => {
   const guardian = m.getParameter('guardian')
   const treasury = m.contract('TreasuryRootstockCollective', [owner, guardian])
 
+  // whitelisting
+  const whitelist = m.getParameter('whitelist')
+  m.call(treasury, 'batchAddWhitelist', [whitelist])
   return { treasury }
 })
 export default treasuryModule

--- a/params/mainnet.json
+++ b/params/mainnet.json
@@ -5,7 +5,7 @@
   },
   "GovernorProxy": {
     "owner": "0x96ee33c87027Be941583A5CAec4B677F269e7C2a",
-    "guardian": "0x96ee33c87027Be941583A5CAec4B677F269e7C2a",
+    "guardian": "0x98fCaB30810804C3Aa945d5BF2D97283a59E1Ac6",
     "votingDelay": 1,
     "votingPeriod": 20160,
     "proposalThreshold": "1000000000000000000000",
@@ -25,6 +25,10 @@
   },
   "Treasury": {
     "owner": "0x96ee33c87027Be941583A5CAec4B677F269e7C2a",
-    "guardian": "0x96ee33c87027Be941583A5CAec4B677F269e7C2a"
+    "guardian": "0x98fCaB30810804C3Aa945d5BF2D97283a59E1Ac6",
+    "whitelist": [
+      "0x2AcC95758f8b5F583470ba265EB685a8F45fC9D5",
+      "0x3A15461d8aE0F0Fb5Fa2629e9DA7D66A794a6e37"
+    ]
   }
 }

--- a/params/testnet.json
+++ b/params/testnet.json
@@ -25,7 +25,10 @@
   },
   "Treasury": {
     "owner": "0xb42c26BB804987EE7FEFb897eB18ED775da19Fe4",
-    "guardian": "0xb42c26BB804987EE7FEFb897eB18ED775da19Fe4"
+    "guardian": "0xb42c26BB804987EE7FEFb897eB18ED775da19Fe4",
+    "whitelist": [
+      "0x19F64674D8A5B4E652319F5e239eFd3bc969A1fE"
+    ]
   },
   "stRIFTokenUpgrade": {
     "StRIFTokenProxyAddress": "0xE7039717C51C44652FB47be1794884A82634f08F"

--- a/test/Treasury.test.ts
+++ b/test/Treasury.test.ts
@@ -29,11 +29,11 @@ describe('Treasury Contract', () => {
   before(async () => {
     ;;[deployer, owner, beneficiary, guardian, collector, token1, token2, token3] = await ethers.getSigners()
     ;({ stRIF, rif, treasury, timelock } = await loadFixture(deployContracts))
-    await treasury.addToWhitelist(rif)
     GuardianRole = await treasury.GUARDIAN_ROLE()
     ExecutorRole = await treasury.EXECUTOR_ROLE()
     const grantRoleTx = await treasury.grantRole(ExecutorRole, deployer)
     await grantRoleTx.wait()
+    await treasury.addToWhitelist(rif)
   })
 
   describe('Withdraw token and RBTC to any account', () => {
@@ -175,21 +175,21 @@ describe('Treasury Contract', () => {
       expect(flag).to.equal(true)
     })
 
-    it('Only account with Guardian Role can add new token to whitelist', async () => {
+    it('Only account with Executor Role can add new token to whitelist', async () => {
       await treasury.connect(deployer).removeFromWhitelist(stRIF)
       expect(await treasury.whitelist(stRIF)).to.equal(false)
 
       const sentTx = treasury.connect(beneficiary).addToWhitelist(stRIF)
       await expect(sentTx)
         .to.be.revertedWithCustomError(treasury, 'AccessControlUnauthorizedAccount')
-        .withArgs(beneficiary.address, GuardianRole)
+        .withArgs(beneficiary.address, ExecutorRole)
     })
 
-    it('Only account with Guardian Role can remove a token to whitelist', async () => {
+    it('Only account with Executor Role can remove a token to whitelist', async () => {
       const sentTx = treasury.connect(beneficiary).removeFromWhitelist(rif)
       await expect(sentTx)
         .to.be.revertedWithCustomError(treasury, 'AccessControlUnauthorizedAccount')
-        .withArgs(beneficiary.address, GuardianRole)
+        .withArgs(beneficiary.address, ExecutorRole)
       expect(await treasury.whitelist(rif)).to.equal(true)
     })
 

--- a/test/Treasury.test.ts
+++ b/test/Treasury.test.ts
@@ -2,7 +2,12 @@ import { ethers } from 'hardhat'
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { deployContracts } from './deployContracts'
-import { RIFToken, StRIFToken, TreasuryRootstockCollective } from '../typechain-types'
+import {
+  RIFToken,
+  StRIFToken,
+  TreasuryRootstockCollective,
+  DaoTimelockUpgradableRootstockCollective,
+} from '../typechain-types'
 import { AddressLike, parseEther } from 'ethers'
 import { expect } from 'chai'
 
@@ -17,12 +22,13 @@ describe('Treasury Contract', () => {
     token3: AddressLike
   let rif: RIFToken
   let treasury: TreasuryRootstockCollective
+  let timelock: DaoTimelockUpgradableRootstockCollective
   let stRIF: StRIFToken
   let GuardianRole: string, ExecutorRole: string
 
   before(async () => {
-    ;[deployer, owner, beneficiary, guardian, collector, token1, token2, token3] = await ethers.getSigners()
-    ;({ stRIF, rif, treasury } = await loadFixture(deployContracts))
+    ;;[deployer, owner, beneficiary, guardian, collector, token1, token2, token3] = await ethers.getSigners()
+    ;({ stRIF, rif, treasury, timelock } = await loadFixture(deployContracts))
     await treasury.addToWhitelist(rif)
     GuardianRole = await treasury.GUARDIAN_ROLE()
     ExecutorRole = await treasury.EXECUTOR_ROLE()
@@ -31,6 +37,9 @@ describe('Treasury Contract', () => {
   })
 
   describe('Withdraw token and RBTC to any account', () => {
+    it('Timelock should be granted the Executor role after deployment', async () => {
+      expect(await treasury.hasRole(ExecutorRole, await timelock.getAddress())).to.be.true
+    })
     it('Receive RBTC', async () => {
       const amount = parseEther('50')
       let balance = await ethers.provider.getBalance(treasury)

--- a/test/Treasury.test.ts
+++ b/test/Treasury.test.ts
@@ -27,13 +27,12 @@ describe('Treasury Contract', () => {
   let GuardianRole: string, ExecutorRole: string
 
   before(async () => {
-    ;;[deployer, owner, beneficiary, guardian, collector, token1, token2, token3] = await ethers.getSigners()
+    ;[deployer, owner, beneficiary, guardian, collector, token1, token2, token3] = await ethers.getSigners()
     ;({ stRIF, rif, treasury, timelock } = await loadFixture(deployContracts))
     GuardianRole = await treasury.GUARDIAN_ROLE()
     ExecutorRole = await treasury.EXECUTOR_ROLE()
     const grantRoleTx = await treasury.grantRole(ExecutorRole, deployer)
     await grantRoleTx.wait()
-    await treasury.addToWhitelist(rif)
   })
 
   describe('Withdraw token and RBTC to any account', () => {

--- a/test/deployContracts.ts
+++ b/test/deployContracts.ts
@@ -37,6 +37,7 @@ export const deployContracts = async () => {
       Treasury: {
         owner: sender.address,
         guardian: sender.address,
+        whitelist: [await rif.getAddress()],
       },
     },
   })

--- a/test/deployContracts.ts
+++ b/test/deployContracts.ts
@@ -9,22 +9,12 @@ import {
 } from '../typechain-types'
 import RifModule from '../ignition/modules/RifModule'
 import GovernorModule from '../ignition/modules/GovernorModule'
-import TreasuryModule from '../ignition/modules/TreasuryModule'
 import EarlyAdoptersModule from '../ignition/modules/EarlyAdoptersModule'
 
 export const deployContracts = async () => {
   const [sender] = await ethers.getSigners()
   // deploy RIF before the rest DAO contracts
   const { rif } = await ignition.deploy(RifModule, { defaultSender: sender?.address })
-  // deploy Treasury
-  const { treasury } = await ignition.deploy(TreasuryModule, {
-    parameters: {
-      Treasury: {
-        owner: sender.address,
-        guardian: sender.address,
-      },
-    },
-  })
   // insert RIF address as a parameter to stRIF deployment module
   const dao = await ignition.deploy(GovernorModule, {
     parameters: {
@@ -44,6 +34,10 @@ export const deployContracts = async () => {
         minDelay: 900,
         admin: sender.address,
       },
+      Treasury: {
+        owner: sender.address,
+        guardian: sender.address,
+      },
     },
   })
   return {
@@ -51,7 +45,7 @@ export const deployContracts = async () => {
     stRIF: dao.stRif as unknown as StRIFToken,
     timelock: dao.timelock as unknown as DaoTimelockUpgradableRootstockCollective,
     governor: dao.governor as unknown as GovernorRootstockCollective,
-    treasury: treasury as unknown as TreasuryRootstockCollective,
+    treasury: dao.treasury as unknown as TreasuryRootstockCollective,
   }
 }
 


### PR DESCRIPTION
# What

- Create `Executor` role for the Treasury contract
- Treasury is now deployed along with other DAO contracts within the Governor module
- The Timelock is assigned the Executor role for the Treasury in the deployment script following deployment.
- Make use of the Executor role in the tests

# Why

The Treasury contract should have two distinct roles: `Default Admin` and `Executor`, instead of just the Default Admin role as it was before. The Default Admin role is assigned to the deployer, whose function is to manage the assignment of other roles. Ideally, only the deployer should have this role.

The Executor role is assigned to the Timelock contract, which will execute Governor proposals, and only it will be able to call the withdraw functions. The Admin should not have the ability to withdraw funds, as that is not part of its function.

The Treasury contract is now deployed after the other contracts within the same module, as it is necessary to call the `grantRole` function post-deployment to assign the Executor role to the Timelock.