### PR TITLE
Rename Plushie NFT to Rootling Series 1 + Security Fix

### DIFF
--- a/contracts/NFT/RootlingSeries1RootstockCollective.sol
+++ b/contracts/NFT/RootlingSeries1RootstockCollective.sol
@@ -224,6 +224,34 @@ contract RootlingSeries1RootstockCollective is
     return maxSupply - _totalMinted;
   }
 
+  /**
+   * @notice Returns the current list of whitelist guards
+   * @return guards Array of addresses that have the `WHITELIST_GUARD_ROLE`
+   */
+  function getWhitelistGuards() external view virtual returns (address[] memory) {
+    return _getRoleMembers(WHITELIST_GUARD_ROLE);
+  }
+
+  /**
+   * @notice Returns the current list of minters
+   * @return minters Array of addresses that have the `MINTER_ROLE`
+   */
+  function getMinters() external view virtual returns (address[] memory) {
+    return _getRoleMembers(MINTER_ROLE);
+  }
+
+  /// @dev Helper to get all members of a role as array
+  function _getRoleMembers(bytes32 role) internal view virtual returns (address[] memory minters) {
+    uint256 numMinters = getRoleMemberCount(role);
+    minters = new address[](numMinters);
+    for (uint256 i = 0; i < numMinters; ) {
+      minters[i] = getRoleMember(role, i);
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
   // OVERRIDES
   /// @dev This function is overridden to provide a single metadata file for all the minters
   function tokenURI(uint256 tokenId) public view override returns (string memory) {

--- a/contracts/NFT/RootlingSeries1RootstockCollective.sol
+++ b/contracts/NFT/RootlingSeries1RootstockCollective.sol
@@ -12,11 +12,11 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
- * @title Plushie Series 1 NFT Collection
+ * @title Rootling Series 1 NFT Collection
  * @notice Non-transferrable POAP-style NFTs for Asia Token 2049 conference participants
  * @dev Whitelisted users can mint once per address. Requires minimum stRIF balance.
  */
-contract PlushieSeries1RootstockCollective is
+contract RootlingSeries1RootstockCollective is
   Initializable,
   ERC721Upgradeable,
   ERC721EnumerableUpgradeable,
@@ -61,19 +61,19 @@ contract PlushieSeries1RootstockCollective is
 
   // EVENTS
 
-  event PlushieNftUnderlyingTokenChanged(IERC20 indexed oldToken, IERC20 indexed newToken);
-  event PlushieNftTokenThresholdChanged(uint256 oldThreshold, uint256 newThreshold);
-  event PlushieNftMaxSupplyChanged(uint256 oldMaxSupply, uint256 newMaxSupply);
-  event PlushieNftFolderIpfsCidChanged(string oldCid, string newCid);
+  event RootlingNftUnderlyingTokenChanged(IERC20 indexed oldToken, IERC20 indexed newToken);
+  event RootlingNftTokenThresholdChanged(uint256 indexed oldThreshold, uint256 indexed newThreshold);
+  event RootlingNftMaxSupplyChanged(uint256 indexed oldMaxSupply, uint256 indexed newMaxSupply);
+  event RootlingNftFolderIpfsCidChanged(string oldCid, string newCid);
 
   // ERRORS
 
-  error PlushieNftOutOfTokens(uint256 maxSupply);
-  error PlushieNftAdminRoleViolation();
-  error PlushieNftTransfersDisabled();
-  error PlushieNftBelowTokenThreshold(uint256 balance, uint256 threshold);
-  error PlushieNftInvalidMaxSupply(uint256 newMaxSupply, uint256 currentMaxSupply);
-  error PlushieNftInvalidAddress(address);
+  error RootlingNftOutOfTokens(uint256 maxSupply);
+  error RootlingNftAdminRoleViolation();
+  error RootlingNftTransfersDisabled();
+  error RootlingNftBelowTokenThreshold(uint256 balance, uint256 threshold);
+  error RootlingNftInvalidMaxSupply(uint256 newMaxSupply, uint256 currentMaxSupply);
+  error RootlingNftInvalidAddress(address);
 
   // INITIALIZERS
 
@@ -89,7 +89,8 @@ contract PlushieSeries1RootstockCollective is
     uint256 initialSupply,
     string calldata ipfsFolderCid
   ) public initializer {
-    __ERC721_init("PlushieSeries1RootstockCollective", "PS1");
+    // solhint-disable-next-line gas-small-strings
+    __ERC721_init("RootlingSeries1RootstockCollective", "RS1");
     __ERC721Enumerable_init();
     __AccessControl_init();
     __AccessControlEnumerable_init();
@@ -117,10 +118,10 @@ contract PlushieSeries1RootstockCollective is
     address caller = _msgSender();
     // checks
     if (balanceOf(caller) > 0) revert ERC721InvalidOwner(caller);
-    if (tokensAvailable() == 0) revert PlushieNftOutOfTokens(maxSupply);
+    if (tokensAvailable() == 0) revert RootlingNftOutOfTokens(maxSupply);
     uint256 balance = underlyingToken.balanceOf(caller);
     if (balance < underlyingTokenThreshold)
-      revert PlushieNftBelowTokenThreshold(balance, underlyingTokenThreshold);
+      revert RootlingNftBelowTokenThreshold(balance, underlyingTokenThreshold);
     // minting
     uint256 tokenId = ++_totalMinted;
     _safeMint(caller, tokenId);
@@ -136,7 +137,7 @@ contract PlushieSeries1RootstockCollective is
     for (uint256 i = 0; i < minters.length; ) {
       _grantRole(MINTER_ROLE, minters[i]);
       unchecked {
-        i++;
+        ++i;
       }
     }
   }
@@ -146,7 +147,7 @@ contract PlushieSeries1RootstockCollective is
     for (uint256 i = 0; i < minters.length; ) {
       _revokeRole(MINTER_ROLE, minters[i]);
       unchecked {
-        i++;
+        ++i;
       }
     }
   }
@@ -156,7 +157,7 @@ contract PlushieSeries1RootstockCollective is
     for (uint256 i = 0; i < guards.length; ) {
       _grantRole(WHITELIST_GUARD_ROLE, guards[i]);
       unchecked {
-        i++;
+        ++i;
       }
     }
   }
@@ -166,7 +167,7 @@ contract PlushieSeries1RootstockCollective is
     for (uint256 i = 0; i < guards.length; ) {
       _revokeRole(WHITELIST_GUARD_ROLE, guards[i]);
       unchecked {
-        i++;
+        ++i;
       }
     }
   }
@@ -177,7 +178,7 @@ contract PlushieSeries1RootstockCollective is
    * @param receiver The address to receive the DEFAULT_ADMIN_ROLE
    */
   function transferDefaultAdminRole(address receiver) external virtual onlyRole(DEFAULT_ADMIN_ROLE) {
-    if (receiver == address(0)) revert PlushieNftInvalidAddress(receiver);
+    if (receiver == address(0)) revert RootlingNftInvalidAddress(receiver);
     _grantRole(DEFAULT_ADMIN_ROLE, receiver);
     _revokeRole(DEFAULT_ADMIN_ROLE, _msgSender());
   }
@@ -188,37 +189,38 @@ contract PlushieSeries1RootstockCollective is
   function setFolderIpfsCid(string calldata cid) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
     string memory oldCid = _metadataIpfsCid;
     _metadataIpfsCid = cid;
-    emit PlushieNftFolderIpfsCidChanged(oldCid, cid);
+    emit RootlingNftFolderIpfsCidChanged(oldCid, cid);
   }
 
   /// @notice Set maximum supply of tokens (can only increase)
   function setMaxSupply(uint256 newMaxSupply) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
-    if (newMaxSupply < maxSupply) revert PlushieNftInvalidMaxSupply(newMaxSupply, maxSupply);
+    if (newMaxSupply < maxSupply) revert RootlingNftInvalidMaxSupply(newMaxSupply, maxSupply);
     uint256 oldMaxSupply = maxSupply;
     maxSupply = newMaxSupply;
-    emit PlushieNftMaxSupplyChanged(oldMaxSupply, newMaxSupply);
+    emit RootlingNftMaxSupplyChanged(oldMaxSupply, newMaxSupply);
   }
 
   /// @notice Set minimum token balance required for minting
   function setTokenThreshold(uint256 threshold) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
     uint256 oldThreshold = underlyingTokenThreshold;
     underlyingTokenThreshold = threshold;
-    emit PlushieNftTokenThresholdChanged(oldThreshold, threshold);
+    emit RootlingNftTokenThresholdChanged(oldThreshold, threshold);
   }
 
   /// @notice Set underlying token contract address
   function setUnderlyingToken(IERC20 newToken) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
-    if (newToken == IERC20(address(0))) revert PlushieNftInvalidAddress(address(newToken));
+    if (newToken == IERC20(address(0))) revert RootlingNftInvalidAddress(address(newToken));
     IERC20 oldToken = underlyingToken;
     underlyingToken = newToken;
-    emit PlushieNftUnderlyingTokenChanged(oldToken, newToken);
+    emit RootlingNftUnderlyingTokenChanged(oldToken, newToken);
   }
 
   // VIEW FUNCTIONS
 
   /// @notice Returns the number of tokens available for minting
   function tokensAvailable() public view virtual returns (uint256) {
-    if (_totalMinted >= maxSupply) return 0;
+    // Safe subtraction: maxSupply >= _totalMinted is guaranteed by contract invariants
+    // (mint() reverts when tokensAvailable() == 0, preventing overflow)
     return maxSupply - _totalMinted;
   }
 
@@ -235,7 +237,7 @@ contract PlushieSeries1RootstockCollective is
     address callerConfirmation
   ) public virtual override(AccessControlUpgradeable, IAccessControl) {
     if (role == DEFAULT_ADMIN_ROLE && getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1) {
-      revert PlushieNftAdminRoleViolation();
+      revert RootlingNftAdminRoleViolation();
     }
     super.renounceRole(role, callerConfirmation);
   }
@@ -245,8 +247,8 @@ contract PlushieSeries1RootstockCollective is
     bytes32 role,
     address account
   ) public virtual override(AccessControlUpgradeable, IAccessControl) {
-    if (role == DEFAULT_ADMIN_ROLE && getRoleMemberCount(DEFAULT_ADMIN_ROLE) >= 1) {
-      revert PlushieNftAdminRoleViolation();
+    if (role == DEFAULT_ADMIN_ROLE && getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1) {
+      revert RootlingNftAdminRoleViolation();
     }
     super.grantRole(role, account);
   }
@@ -259,21 +261,28 @@ contract PlushieSeries1RootstockCollective is
   ) internal override(ERC721Upgradeable, ERC721EnumerableUpgradeable) returns (address) {
     address from = _ownerOf(tokenId);
     // restrict usual transfers (except burning and minting)
-    if (from != address(0) && to != address(0)) revert PlushieNftTransfersDisabled();
+    if (from != address(0) && to != address(0)) revert RootlingNftTransfersDisabled();
 
     return super._update(to, tokenId, auth);
   }
 
   /// @dev This function is overridden to prevent from granting roles to zero address.
   function _grantRole(bytes32 role, address receiver) internal virtual override returns (bool) {
-    if (receiver == address(0)) revert PlushieNftAdminRoleViolation();
+    if (receiver == address(0)) revert RootlingNftAdminRoleViolation();
     return super._grantRole(role, receiver);
   }
 
   /// @dev Restricts contract upgrades to accounts with DEFAULT_ADMIN_ROLE
   function _authorizeUpgrade(
     address newImplementation
-  ) internal virtual override onlyRole(DEFAULT_ADMIN_ROLE) {}
+  )
+    internal
+    virtual
+    override
+    onlyRole(DEFAULT_ADMIN_ROLE) // solhint-disable-next-line no-empty-blocks
+  {
+    // Intentionally empty - authorization handled by access control
+  }
 
   // The following functions are overrides required by Solidity.
 

--- a/contracts/NFT/RootlingSeries1RootstockCollective.sol
+++ b/contracts/NFT/RootlingSeries1RootstockCollective.sol
@@ -117,9 +117,9 @@ contract RootlingSeries1RootstockCollective is
   function mint() external onlyRole(MINTER_ROLE) returns (uint256) {
     address caller = _msgSender();
     // checks
+    uint256 balance = underlyingToken.balanceOf(caller);
     if (balanceOf(caller) > 0) revert ERC721InvalidOwner(caller);
     if (tokensAvailable() == 0) revert RootlingNftOutOfTokens(maxSupply);
-    uint256 balance = underlyingToken.balanceOf(caller);
     if (balance < underlyingTokenThreshold)
       revert RootlingNftBelowTokenThreshold(balance, underlyingTokenThreshold);
     // minting

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -102,22 +102,12 @@ const config: HardhatUserConfig = {
           url: 'https://rootstock-testnet.blockscout.com',
           apiUrl: 'https://rootstock-testnet.blockscout.com/api',
         },
-        etherscan: {
-          name: 'Rootstock Blockscout',
-          url: 'https://rootstock.blockscout.com',
-          apiUrl: 'https://rootstock.blockscout.com/api',
-        },
       },
     },
     30: {
       name: 'rootstockMainnet',
       blockExplorers: {
         blockscout: {
-          name: 'Rootstock Blockscout',
-          url: 'https://rootstock.blockscout.com',
-          apiUrl: 'https://rootstock.blockscout.com/api',
-        },
-        etherscan: {
           name: 'Rootstock Blockscout',
           url: 'https://rootstock.blockscout.com',
           apiUrl: 'https://rootstock.blockscout.com/api',

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -102,12 +102,22 @@ const config: HardhatUserConfig = {
           url: 'https://rootstock-testnet.blockscout.com',
           apiUrl: 'https://rootstock-testnet.blockscout.com/api',
         },
+        etherscan: {
+          name: 'Rootstock Blockscout',
+          url: 'https://rootstock.blockscout.com',
+          apiUrl: 'https://rootstock.blockscout.com/api',
+        },
       },
     },
     30: {
       name: 'rootstockMainnet',
       blockExplorers: {
         blockscout: {
+          name: 'Rootstock Blockscout',
+          url: 'https://rootstock.blockscout.com',
+          apiUrl: 'https://rootstock.blockscout.com/api',
+        },
+        etherscan: {
           name: 'Rootstock Blockscout',
           url: 'https://rootstock.blockscout.com',
           apiUrl: 'https://rootstock.blockscout.com/api',

--- a/ignition/modules/RootlingSeries1Module.ts
+++ b/ignition/modules/RootlingSeries1Module.ts
@@ -1,6 +1,6 @@
 import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
 
-export const rootlingSeries1Module = buildModule('RootlingSeries1', m => {
+export const RootlingSeries1Module = buildModule('RootlingSeries1', m => {
   // deploy implementation
   const implementation = m.contract('RootlingSeries1RootstockCollective', [], { id: 'Implementation' })
 
@@ -28,4 +28,4 @@ export const rootlingSeries1Module = buildModule('RootlingSeries1', m => {
   return { RootlingSeries1 }
 })
 
-export default rootlingSeries1Module
+export default RootlingSeries1Module

--- a/ignition/modules/RootlingSeries1Module.ts
+++ b/ignition/modules/RootlingSeries1Module.ts
@@ -1,8 +1,8 @@
 import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
 
-export const PlushieSeries1Module = buildModule('PlushieSeries1', m => {
+export const rootlingSeries1Module = buildModule('RootlingSeries1', m => {
   // deploy implementation
-  const implementation = m.contract('PlushieSeries1RootstockCollective', [], { id: 'Implementation' })
+  const implementation = m.contract('RootlingSeries1RootstockCollective', [], { id: 'Implementation' })
 
   const deployer = m.getAccount(0)
   const stRif = m.getParameter('stRif')
@@ -21,11 +21,11 @@ export const PlushieSeries1Module = buildModule('PlushieSeries1', m => {
       },
     ),
   ])
-  const plushieSeries1 = m.contractAt('PlushieSeries1RootstockCollective', proxy, {
+  const RootlingSeries1 = m.contractAt('RootlingSeries1RootstockCollective', proxy, {
     id: 'Contract',
   })
 
-  return { plushieSeries1 }
+  return { RootlingSeries1 }
 })
 
-export default PlushieSeries1Module
+export default rootlingSeries1Module

--- a/params/RootlingS1/testnet.json
+++ b/params/RootlingS1/testnet.json
@@ -1,0 +1,8 @@
+{
+  "RootlingSeries1": {
+    "stRif": "0x4861198e9A6814EBfb152552D1b1a37426C54D23",
+    "stRifThreshold": "1000000000000000000",
+    "maxSupply": 400,
+    "ipfsFolderCid": "QmRPHxGyqGiB47WVkbMUxgEVvo8o8KxXqvuPgVH7dU12aE"
+  }
+}

--- a/test/RootlingSeries1.test.ts
+++ b/test/RootlingSeries1.test.ts
@@ -300,6 +300,23 @@ describe('RootlingSeries1RootstockCollective NFT', () => {
 
         await expect(rootling.connect(whitelistGuardAlice).removeFromWhitelist([])).to.not.revert(ethers)
       })
+
+      it('getMinters() returns correct list of whitelisted addresses', async () => {
+        const mintersFromContract = await rootling.getMinters()
+        console.log('🚀 ~ minters:', mintersFromContract)
+
+        // Should have 4 addresses: contract address + minters[0] + minters[1] + one more
+        expect(mintersFromContract).to.have.lengthOf(4)
+        expect(mintersFromContract).to.include(await rootling.getAddress())
+        expect(mintersFromContract).to.include(await minters[0].getAddress())
+        expect(mintersFromContract).to.include(await minters[1].getAddress())
+        expect(mintersFromContract).to.include(await whitelistGuardAlice.getAddress())
+
+        // Verify all returned addresses actually have the MINTER_ROLE
+        for (const minter of mintersFromContract) {
+          expect(await rootling.hasRole(minterRole, minter)).to.be.true
+        }
+      })
     })
     describe('Sad path', () => {
       it('Whitelist guard cannot add zero address to whitelist', async () => {
@@ -619,6 +636,28 @@ describe('RootlingSeries1RootstockCollective NFT', () => {
         for (let tokenId = 1; tokenId <= maxSupply; tokenId++) {
           const tokenUri = await rootling.tokenURI(tokenId)
           expect(tokenUri).to.equal(`ipfs://${ipfsFolderCid}`)
+        }
+      })
+
+      it('getWhitelistGuards() returns correct list of guards', async () => {
+        const guards = await rootling.getWhitelistGuards()
+
+        expect(guards).to.have.lengthOf(3)
+        expect(guards).to.include(await deployer.getAddress())
+        expect(guards).to.include(await whitelistGuardBob.getAddress())
+        expect(guards).to.include(await whitelistGuardAlice.getAddress())
+      })
+
+      it('getMinters() returns addresses that still have MINTER_ROLE after supply exhausted', async () => {
+        const minters = await rootling.getMinters()
+        console.log('🚀 ~ final minters count:', minters.length)
+
+        // Should have addresses that were whitelisted but couldn't mint due to supply exhaustion
+        expect(minters.length).to.be.greaterThan(0)
+
+        // Verify all returned addresses actually have the MINTER_ROLE
+        for (const minter of minters) {
+          expect(await rootling.hasRole(minterRole, minter)).to.be.true
         }
       })
     })

--- a/test/RootlingSeries1.test.ts
+++ b/test/RootlingSeries1.test.ts
@@ -1,6 +1,6 @@
-import { PlushieSeries1Module } from '../ignition/modules/PlushieSeries1Module.js'
+import { rootlingSeries1Module } from '../ignition/modules/RootlingSeries1Module.js'
 import type {
-  PlushieSeries1RootstockCollective,
+  RootlingSeries1RootstockCollective,
   RIFToken,
   StRIFToken,
 } from '../types/ethers-contracts/index.js'
@@ -14,10 +14,10 @@ const minterRole = ethers.keccak256(ethers.toUtf8Bytes('MINTER_ROLE'))
 const whitelistGuardRole = ethers.keccak256(ethers.toUtf8Bytes('WHITELIST_GUARD_ROLE'))
 const adminRole = ethers.ZeroHash
 
-async function deployPlushieNft(stRifAddress: string) {
-  const { plushieSeries1 } = await ignition.deploy(PlushieSeries1Module, {
+async function deployRootlingNft(stRifAddress: string) {
+  const { RootlingSeries1 } = await ignition.deploy(rootlingSeries1Module, {
     parameters: {
-      PlushieSeries1: {
+      RootlingSeries1: {
         stRif: stRifAddress,
         stRifThreshold,
         maxSupply,
@@ -25,11 +25,11 @@ async function deployPlushieNft(stRifAddress: string) {
       },
     },
   })
-  return plushieSeries1 as unknown as PlushieSeries1RootstockCollective
+  return RootlingSeries1 as unknown as RootlingSeries1RootstockCollective
 }
 
-describe('PlushieSeries1RootstockCollective NFT', () => {
-  let plushie: PlushieSeries1RootstockCollective
+describe('RootlingSeries1RootstockCollective NFT', () => {
+  let rootling: RootlingSeries1RootstockCollective
   let deployer: Signer
   let whitelistGuardAlice: Signer
   let whitelistGuardBob: Signer
@@ -52,149 +52,148 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
 
     await sendStRifsTo(...minters.slice(0, -1))
     const stRifAddress = await stRIF.getAddress()
-    plushie = await deployPlushieNft(stRifAddress)
+    rootling = await deployRootlingNft(stRifAddress)
   })
 
   describe('upon deployment', () => {
     it('should set up proper NFT name and symbol', async () => {
-      expect(await plushie.name()).to.equal('PlushieSeries1RootstockCollective')
-      expect(await plushie.symbol()).to.equal('PS1')
+      expect(await rootling.name()).to.equal('RootlingSeries1RootstockCollective')
+      expect(await rootling.symbol()).to.equal('RS1')
     })
     it('Minter role should be set up', async () => {
-      expect(await plushie.MINTER_ROLE()).to.equal(minterRole)
+      expect(await rootling.MINTER_ROLE()).to.equal(minterRole)
     })
     it('Admin role should be set up', async () => {
-      expect(await plushie.DEFAULT_ADMIN_ROLE()).to.equal(adminRole)
+      expect(await rootling.DEFAULT_ADMIN_ROLE()).to.equal(adminRole)
     })
     it('Whitelist Guard role should be set up', async () => {
-      expect(await plushie.WHITELIST_GUARD_ROLE()).to.equal(whitelistGuardRole)
+      expect(await rootling.WHITELIST_GUARD_ROLE()).to.equal(whitelistGuardRole)
     })
     it('Minter role should be administrated by Whitelist guard role', async () => {
-      expect(await plushie.getRoleAdmin(minterRole)).to.equal(whitelistGuardRole)
+      expect(await rootling.getRoleAdmin(minterRole)).to.equal(whitelistGuardRole)
     })
     it('Deployer should be granted the admin role', async () => {
-      expect(await plushie.hasRole(adminRole, await deployer.getAddress())).to.be.true
+      expect(await rootling.hasRole(adminRole, await deployer.getAddress())).to.be.true
     })
     it('Deployer should be granted the Whitelist guard role', async () => {
-      expect(await plushie.hasRole(whitelistGuardRole, await deployer.getAddress())).to.be.true
+      expect(await rootling.hasRole(whitelistGuardRole, await deployer.getAddress())).to.be.true
     })
     it('Should set max supply correctly', async () => {
-      expect(await plushie.maxSupply()).to.equal(maxSupply)
+      expect(await rootling.maxSupply()).to.equal(maxSupply)
     })
     it('NFT contract should have Max supply of available tokens', async () => {
-      expect(await plushie.tokensAvailable()).to.equal(maxSupply)
+      expect(await rootling.tokensAvailable()).to.equal(maxSupply)
     })
     it('Should set StRif as underlying token', async () => {
-      expect(await plushie.underlyingToken()).to.equal(await stRIF.getAddress())
+      expect(await rootling.underlyingToken()).to.equal(await stRIF.getAddress())
     })
     it('Should set StRif threshold for NFT minting', async () => {
-      expect(await plushie.underlyingTokenThreshold()).to.equal(stRifThreshold)
+      expect(await rootling.underlyingTokenThreshold()).to.equal(stRifThreshold)
     })
   })
 
   describe('Role Management & Access Control', () => {
     describe('Happy path', () => {
       it('Admin should grant Whitelist Guard role to both Alice and Bob', async () => {
-        const tx = plushie.addWhitelistGuards([
+        const tx = rootling.addWhitelistGuards([
           await whitelistGuardAlice.getAddress(),
           await whitelistGuardBob.getAddress(),
         ])
         await expect(tx)
-          .to.emit(plushie, 'RoleGranted')
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(whitelistGuardRole, await whitelistGuardAlice.getAddress(), await deployer.getAddress())
         await expect(tx)
-          .to.emit(plushie, 'RoleGranted')
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(whitelistGuardRole, await whitelistGuardBob.getAddress(), await deployer.getAddress())
       })
       it('Alice and Bob should be whitelist guards now', async () => {
-        expect(await plushie.hasRole(whitelistGuardRole, await whitelistGuardAlice.getAddress())).to.be.true
-        expect(await plushie.hasRole(whitelistGuardRole, await whitelistGuardBob.getAddress())).to.be.true
+        expect(await rootling.hasRole(whitelistGuardRole, await whitelistGuardAlice.getAddress())).to.be.true
+        expect(await rootling.hasRole(whitelistGuardRole, await whitelistGuardBob.getAddress())).to.be.true
       })
       it('Whitelist guards can whitelist addresses', async () => {
-        const tx = plushie
+        const tx = rootling
           .connect(whitelistGuardAlice)
           .addToWhitelist([await minters[0].getAddress(), await minters[1].getAddress()])
 
         await expect(tx)
-          .to.emit(plushie, 'RoleGranted')
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(minterRole, await minters[0].getAddress(), await whitelistGuardAlice.getAddress())
         await expect(tx)
-          .to.emit(plushie, 'RoleGranted')
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(minterRole, await minters[1].getAddress(), await whitelistGuardAlice.getAddress())
 
         // Verify they have minter roles
-        expect(await plushie.hasRole(minterRole, await minters[0].getAddress())).to.be.true
-        expect(await plushie.hasRole(minterRole, await minters[1].getAddress())).to.be.true
+        expect(await rootling.hasRole(minterRole, await minters[0].getAddress())).to.be.true
+        expect(await rootling.hasRole(minterRole, await minters[1].getAddress())).to.be.true
       })
       it('Deployer can transfer DEFAULT_ADMIN_ROLE to another address', async () => {
         const newAdmin = minters[0] // Use first minter as new admin
 
         // Verify initial state: deployer has admin role, newAdmin doesn't
-        expect(await plushie.hasRole(adminRole, await deployer.getAddress())).to.be.true
-        expect(await plushie.hasRole(adminRole, await newAdmin.getAddress())).to.be.false
-        expect(await plushie.getRoleMemberCount(adminRole)).to.equal(1)
+        expect(await rootling.hasRole(adminRole, await deployer.getAddress())).to.be.true
+        expect(await rootling.hasRole(adminRole, await newAdmin.getAddress())).to.be.false
+        expect(await rootling.getRoleMemberCount(adminRole)).to.equal(1)
 
         // Transfer admin role to new address
-        const tx = plushie.transferDefaultAdminRole(await newAdmin.getAddress())
+        const tx = rootling.transferDefaultAdminRole(await newAdmin.getAddress())
         await expect(tx)
-          .to.emit(plushie, 'RoleGranted')
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(adminRole, await newAdmin.getAddress(), await deployer.getAddress())
         await expect(tx)
-          .to.emit(plushie, 'RoleRevoked')
+          .to.emit(rootling, 'RoleRevoked')
           .withArgs(adminRole, await deployer.getAddress(), await deployer.getAddress())
 
         // Verify final state: only newAdmin has admin role
-        expect(await plushie.hasRole(adminRole, await deployer.getAddress())).to.be.false
-        expect(await plushie.hasRole(adminRole, await newAdmin.getAddress())).to.be.true
-        expect(await plushie.getRoleMemberCount(adminRole)).to.equal(1)
+        expect(await rootling.hasRole(adminRole, await deployer.getAddress())).to.be.false
+        expect(await rootling.hasRole(adminRole, await newAdmin.getAddress())).to.be.true
+        expect(await rootling.getRoleMemberCount(adminRole)).to.equal(1)
 
         // Verify new admin can perform admin functions
         const newCid = 'QmNewTestCid123'
-        await expect(plushie.connect(newAdmin).setFolderIpfsCid(newCid))
-          .to.emit(plushie, 'PlushieNftFolderIpfsCidChanged')
+        await expect(rootling.connect(newAdmin).setFolderIpfsCid(newCid))
+          .to.emit(rootling, 'RootlingNftFolderIpfsCidChanged')
           .withArgs(ipfsFolderCid, newCid)
 
         // give admin role back for testing convenience
-        await plushie
+        await rootling
           .connect(newAdmin)
           .transferDefaultAdminRole(await deployer.getAddress())
           .then(tx => tx.wait())
-        await plushie.setFolderIpfsCid(ipfsFolderCid).then(tx => tx.wait())
+        await rootling.setFolderIpfsCid(ipfsFolderCid).then(tx => tx.wait())
       })
     })
     describe('Sad path', () => {
       it('Stranger cannot grant himself Whitelist Guard role', async () => {
-        await expect(plushie.connect(stranger).addWhitelistGuards([await stranger.getAddress()]))
-          .to.be.revertedWithCustomError(plushie, 'AccessControlUnauthorizedAccount')
+        await expect(rootling.connect(stranger).addWhitelistGuards([await stranger.getAddress()]))
+          .to.be.revertedWithCustomError(rootling, 'AccessControlUnauthorizedAccount')
           .withArgs(await stranger.getAddress(), adminRole)
       })
       it('Whitelist Guards cannot grant Whitelist Guard role to extraneous address', async () => {
-        await expect(plushie.connect(whitelistGuardAlice).addWhitelistGuards([await stranger.getAddress()]))
-          .to.be.revertedWithCustomError(plushie, 'AccessControlUnauthorizedAccount')
+        await expect(rootling.connect(whitelistGuardAlice).addWhitelistGuards([await stranger.getAddress()]))
+          .to.be.revertedWithCustomError(rootling, 'AccessControlUnauthorizedAccount')
           .withArgs(await whitelistGuardAlice.getAddress(), adminRole)
       })
       it('Default admin cannot renounce his role when he is the last admin', async () => {
         await expect(
-          plushie.renounceRole(adminRole, await deployer.getAddress()),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftAdminRoleViolation')
+          rootling.renounceRole(adminRole, await deployer.getAddress()),
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftAdminRoleViolation')
       })
       it('Cannot grant second admin role - only one admin allowed', async () => {
-        await expect(plushie.grantRole(adminRole, await stranger.getAddress())).to.be.revertedWithCustomError(
-          plushie,
-          'PlushieNftAdminRoleViolation',
-        )
+        await expect(
+          rootling.grantRole(adminRole, await stranger.getAddress()),
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftAdminRoleViolation')
       })
       it('Owner removes whitelist guard role, then that address tries to modify whitelist', async () => {
         // Remove Alice's whitelist guard role
-        await plushie.removeWhitelistGuards([await whitelistGuardAlice.getAddress()]).then(tx => tx.wait())
+        await rootling.removeWhitelistGuards([await whitelistGuardAlice.getAddress()]).then(tx => tx.wait())
         // Verify Alice no longer has the role
-        expect(await plushie.hasRole(whitelistGuardRole, await whitelistGuardAlice.getAddress())).to.be.false
+        expect(await rootling.hasRole(whitelistGuardRole, await whitelistGuardAlice.getAddress())).to.be.false
         // Alice tries to whitelist someone but should fail
-        await expect(plushie.connect(whitelistGuardAlice).addToWhitelist([await stranger.getAddress()]))
-          .to.be.revertedWithCustomError(plushie, 'AccessControlUnauthorizedAccount')
+        await expect(rootling.connect(whitelistGuardAlice).addToWhitelist([await stranger.getAddress()]))
+          .to.be.revertedWithCustomError(rootling, 'AccessControlUnauthorizedAccount')
           .withArgs(await whitelistGuardAlice.getAddress(), whitelistGuardRole)
         // return guard role to Alice
-        await plushie.addWhitelistGuards([await whitelistGuardAlice.getAddress()]).then(tx => tx.wait())
+        await rootling.addWhitelistGuards([await whitelistGuardAlice.getAddress()]).then(tx => tx.wait())
       })
     })
   })
@@ -203,70 +202,70 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
     describe('Happy path', () => {
       it('Whitelist guard can add themselves to the minting whitelist', async () => {
         await expect(
-          plushie.connect(whitelistGuardAlice).addToWhitelist([await whitelistGuardAlice.getAddress()]),
+          rootling.connect(whitelistGuardAlice).addToWhitelist([await whitelistGuardAlice.getAddress()]),
         )
-          .to.emit(plushie, 'RoleGranted')
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(
             minterRole,
             await whitelistGuardAlice.getAddress(),
             await whitelistGuardAlice.getAddress(),
           )
 
-        expect(await plushie.hasRole(minterRole, await whitelistGuardAlice.getAddress())).to.be.true
+        expect(await rootling.hasRole(minterRole, await whitelistGuardAlice.getAddress())).to.be.true
       })
 
       it('Add the same address to whitelist multiple times - handle gracefully', async () => {
         // First addition
-        await plushie
+        await rootling
           .connect(whitelistGuardAlice)
           .addToWhitelist([await stranger.getAddress()])
           .then(tx => tx.wait())
-        expect(await plushie.hasRole(minterRole, await stranger.getAddress())).to.be.true
+        expect(await rootling.hasRole(minterRole, await stranger.getAddress())).to.be.true
 
         // Second addition - should not revert, just no-op
         await expect(
-          plushie.connect(whitelistGuardAlice).addToWhitelist([await stranger.getAddress()]),
+          rootling.connect(whitelistGuardAlice).addToWhitelist([await stranger.getAddress()]),
         ).to.not.revert(ethers)
 
         // Still has the role
-        expect(await plushie.hasRole(minterRole, await stranger.getAddress())).to.be.true
+        expect(await rootling.hasRole(minterRole, await stranger.getAddress())).to.be.true
       })
 
       it('Remove non-whitelisted address from whitelist - handle gracefully', async () => {
         // Try to remove address that was never whitelisted
         await expect(
-          plushie.connect(whitelistGuardAlice).removeFromWhitelist([await stranger.getAddress()]),
+          rootling.connect(whitelistGuardAlice).removeFromWhitelist([await stranger.getAddress()]),
         ).to.not.revert(ethers)
 
         // Verify they still don't have the role
-        expect(await plushie.hasRole(minterRole, await stranger.getAddress())).to.be.false
+        expect(await rootling.hasRole(minterRole, await stranger.getAddress())).to.be.false
       })
 
       it('Add contract address itself to whitelist - handle gracefully', async () => {
-        const contractAddress = await plushie.getAddress()
+        const contractAddress = await rootling.getAddress()
 
-        await expect(plushie.connect(whitelistGuardAlice).addToWhitelist([contractAddress]))
-          .to.emit(plushie, 'RoleGranted')
+        await expect(rootling.connect(whitelistGuardAlice).addToWhitelist([contractAddress]))
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(minterRole, contractAddress, await whitelistGuardAlice.getAddress())
 
-        expect(await plushie.hasRole(minterRole, contractAddress)).to.be.true
+        expect(await rootling.hasRole(minterRole, contractAddress)).to.be.true
       })
 
       it('Batch whitelist operations: Add multiple addresses in single transaction', async () => {
         const addresses = minters.slice(10, 15).map(s => s.getAddress()) // 5 addresses
 
-        const tx = plushie.connect(whitelistGuardAlice).addToWhitelist(addresses)
+        const tx = rootling.connect(whitelistGuardAlice).addToWhitelist(addresses)
 
         // Check all events are emitted
         const eventChecks = addresses.map(async address =>
           expect(tx)
-            .to.emit(plushie, 'RoleGranted')
+            .to.emit(rootling, 'RoleGranted')
             .withArgs(minterRole, address, await whitelistGuardAlice.getAddress()),
         )
         await Promise.all(eventChecks)
 
         // Verify all have minter roles
-        const roleChecks = addresses.map(address => plushie.hasRole(minterRole, address))
+        const roleChecks = addresses.map(address => rootling.hasRole(minterRole, address))
         const results = await Promise.all(roleChecks)
         results.forEach(hasRole => {
           expect(hasRole).to.be.true
@@ -277,18 +276,18 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         const addresses = minters.slice(10, 15).map(s => s.getAddress()) // 5 addresses
 
         // Then remove them
-        const tx = plushie.connect(whitelistGuardAlice).removeFromWhitelist(addresses)
+        const tx = rootling.connect(whitelistGuardAlice).removeFromWhitelist(addresses)
 
         // Check all revoke events are emitted
         const eventChecks = addresses.map(async address =>
           expect(tx)
-            .to.emit(plushie, 'RoleRevoked')
+            .to.emit(rootling, 'RoleRevoked')
             .withArgs(minterRole, address, await whitelistGuardAlice.getAddress()),
         )
         await Promise.all(eventChecks)
 
         // Verify all lost minter roles
-        const roleChecks = addresses.map(address => plushie.hasRole(minterRole, address))
+        const roleChecks = addresses.map(address => rootling.hasRole(minterRole, address))
         const results = await Promise.all(roleChecks)
         results.forEach(hasRole => {
           expect(hasRole).to.be.false
@@ -297,19 +296,19 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
 
       it('Whitelisting empty array - handle gracefully', async () => {
         // Empty array should not revert
-        await expect(plushie.connect(whitelistGuardAlice).addToWhitelist([])).to.not.revert(ethers)
+        await expect(rootling.connect(whitelistGuardAlice).addToWhitelist([])).to.not.revert(ethers)
 
-        await expect(plushie.connect(whitelistGuardAlice).removeFromWhitelist([])).to.not.revert(ethers)
+        await expect(rootling.connect(whitelistGuardAlice).removeFromWhitelist([])).to.not.revert(ethers)
       })
     })
     describe('Sad path', () => {
       it('Whitelist guard cannot add zero address to whitelist', async () => {
         await expect(
-          plushie.connect(whitelistGuardAlice).addToWhitelist([ethers.ZeroAddress]),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftAdminRoleViolation')
+          rootling.connect(whitelistGuardAlice).addToWhitelist([ethers.ZeroAddress]),
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftAdminRoleViolation')
 
         // But verify the behavior
-        expect(await plushie.hasRole(minterRole, ethers.ZeroAddress)).to.be.false
+        expect(await rootling.hasRole(minterRole, ethers.ZeroAddress)).to.be.false
       })
 
       it('Batch whitelist with zero address mixed with valid addresses - should fail', async () => {
@@ -317,18 +316,18 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         const mixedAddresses = [validAddresses[0], ethers.ZeroAddress, validAddresses[1]]
 
         await expect(
-          plushie.connect(whitelistGuardAlice).addToWhitelist(mixedAddresses),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftAdminRoleViolation')
+          rootling.connect(whitelistGuardAlice).addToWhitelist(mixedAddresses),
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftAdminRoleViolation')
 
         // Verify none of the addresses got the role (transaction reverted)
-        const roleChecks = validAddresses.map(address => plushie.hasRole(minterRole, address))
+        const roleChecks = validAddresses.map(address => rootling.hasRole(minterRole, address))
         const results = await Promise.all(roleChecks)
         results.forEach(hasRole => {
           expect(hasRole).to.be.false
         })
 
         // Zero address also shouldn't have the role
-        expect(await plushie.hasRole(minterRole, ethers.ZeroAddress)).to.be.false
+        expect(await rootling.hasRole(minterRole, ethers.ZeroAddress)).to.be.false
       })
     })
   })
@@ -339,41 +338,41 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
       it('User gets minter role when whitelisted', async () => {
         // Whitelist a user
         await expect(
-          plushie.connect(whitelistGuardAlice).addToWhitelist([await minters[minterNum].getAddress()]),
+          rootling.connect(whitelistGuardAlice).addToWhitelist([await minters[minterNum].getAddress()]),
         )
-          .to.emit(plushie, 'RoleGranted')
+          .to.emit(rootling, 'RoleGranted')
           .withArgs(minterRole, await minters[minterNum].getAddress(), await whitelistGuardAlice.getAddress())
 
         // Verify user received the Minter role
-        expect(await plushie.hasRole(minterRole, await minters[minterNum].getAddress())).to.be.true
+        expect(await rootling.hasRole(minterRole, await minters[minterNum].getAddress())).to.be.true
       })
 
       it('Whitelisted user can successfully mint NFT', async () => {
         // User mints successfully
-        await expect(plushie.connect(minters[minterNum]).mint())
-          .to.emit(plushie, 'Transfer')
+        await expect(rootling.connect(minters[minterNum]).mint())
+          .to.emit(rootling, 'Transfer')
           .withArgs(ethers.ZeroAddress, await minters[minterNum].getAddress(), 1)
       })
 
       it('User owns the minted NFT', async () => {
         // Verify user owns the NFT
-        expect(await plushie.balanceOf(await minters[minterNum].getAddress())).to.equal(1)
-        expect(await plushie.ownerOf(1)).to.equal(await minters[minterNum].getAddress())
+        expect(await rootling.balanceOf(await minters[minterNum].getAddress())).to.equal(1)
+        expect(await rootling.ownerOf(1)).to.equal(await minters[minterNum].getAddress())
       })
 
       it('User loses minter role after minting', async () => {
         // Verify user no longer has minter role
-        expect(await plushie.hasRole(minterRole, await minters[minterNum].getAddress())).to.be.false
+        expect(await rootling.hasRole(minterRole, await minters[minterNum].getAddress())).to.be.false
       })
 
       it('Token has correct metadata URI', async () => {
         // Verify token URI is set correctly
-        expect(await plushie.tokenURI(1)).to.equal(`ipfs://${ipfsFolderCid}`)
+        expect(await rootling.tokenURI(1)).to.equal(`ipfs://${ipfsFolderCid}`)
       })
 
       it('Tokens available count decreases after mint', async () => {
         // Verify available tokens decreased
-        expect(await plushie.tokensAvailable()).to.equal(maxSupply - 1)
+        expect(await rootling.tokensAvailable()).to.equal(maxSupply - 1)
       })
     })
     describe('Sad path', () => {
@@ -382,53 +381,53 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         const poorUser = minters[minters.length - 1]
 
         // Whitelist the poor user (give them minter role)
-        await plushie.connect(whitelistGuardAlice).addToWhitelist([await poorUser.getAddress()])
-        expect(await plushie.hasRole(minterRole, await poorUser.getAddress())).to.be.true
+        await rootling.connect(whitelistGuardAlice).addToWhitelist([await poorUser.getAddress()])
+        expect(await rootling.hasRole(minterRole, await poorUser.getAddress())).to.be.true
 
         // Verify they have insufficient stRIF balance (should be 0)
         const userBalance = await stRIF.balanceOf(await poorUser.getAddress())
         expect(userBalance).to.be.lt(stRifThreshold)
 
         // Attempt to mint should fail with balance threshold error
-        await expect(plushie.connect(poorUser).mint())
-          .to.be.revertedWithCustomError(plushie, 'PlushieNftBelowTokenThreshold')
+        await expect(rootling.connect(poorUser).mint())
+          .to.be.revertedWithCustomError(rootling, 'RootlingNftBelowTokenThreshold')
           .withArgs(userBalance, stRifThreshold)
       })
       it('User who is not in the whitelist cannot mint NFT', async () => {
-        await expect(plushie.connect(stranger).mint())
-          .to.be.revertedWithCustomError(plushie, 'AccessControlUnauthorizedAccount')
+        await expect(rootling.connect(stranger).mint())
+          .to.be.revertedWithCustomError(rootling, 'AccessControlUnauthorizedAccount')
           .withArgs(await stranger.getAddress(), minterRole)
       })
 
       it('Admin role who is not in the whitelist cannot mint NFT', async () => {
-        await expect(plushie.connect(deployer).mint())
-          .to.be.revertedWithCustomError(plushie, 'AccessControlUnauthorizedAccount')
+        await expect(rootling.connect(deployer).mint())
+          .to.be.revertedWithCustomError(rootling, 'AccessControlUnauthorizedAccount')
           .withArgs(await deployer.getAddress(), minterRole)
       })
 
       it('Whitelist guard who is not in the whitelist cannot mint NFT', async () => {
         // dewhitelist previously whitelisted guard (by another guard)
-        await plushie
+        await rootling
           .connect(whitelistGuardBob)
           .removeFromWhitelist([await whitelistGuardAlice.getAddress()])
           .then(tx => tx.wait())
         // make sure the guard was removed from whitelist
-        expect(await plushie.hasRole(minterRole, await whitelistGuardAlice.getAddress())).to.be.false
+        expect(await rootling.hasRole(minterRole, await whitelistGuardAlice.getAddress())).to.be.false
         // trying to mint
-        await expect(plushie.connect(whitelistGuardAlice).mint())
-          .to.be.revertedWithCustomError(plushie, 'AccessControlUnauthorizedAccount')
+        await expect(rootling.connect(whitelistGuardAlice).mint())
+          .to.be.revertedWithCustomError(rootling, 'AccessControlUnauthorizedAccount')
           .withArgs(await whitelistGuardAlice.getAddress(), minterRole)
       })
 
       it('Address who already minted NFT cannot mint another NFT event after granting another minter role', async () => {
         // Whitelist and mint first NFT
-        await plushie
+        await rootling
           .connect(whitelistGuardAlice)
           .addToWhitelist([await minters[minterNum].getAddress()])
           .then(tx => tx.wait())
-        expect(await plushie.hasRole(minterRole, await minters[minterNum].getAddress())).to.be.true
-        await expect(plushie.connect(minters[minterNum]).mint())
-          .to.be.revertedWithCustomError(plushie, 'ERC721InvalidOwner')
+        expect(await rootling.hasRole(minterRole, await minters[minterNum].getAddress())).to.be.true
+        await expect(rootling.connect(minters[minterNum]).mint())
+          .to.be.revertedWithCustomError(rootling, 'ERC721InvalidOwner')
           .withArgs(await minters[minterNum].getAddress())
       })
     })
@@ -443,29 +442,29 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         const addresses = availableMintersIndices.map(i => minters[i].getAddress())
 
         // Whitelist all users
-        await plushie.connect(whitelistGuardBob).addToWhitelist(addresses)
+        await rootling.connect(whitelistGuardBob).addToWhitelist(addresses)
 
         // Mint 7 NFTs
         for (const index of availableMintersIndices) {
-          await plushie
+          await rootling
             .connect(minters[index])
             .mint()
             .then(tx => tx.wait())
         }
 
         // Verify we have 8 total minted
-        expect(await plushie.tokensAvailable()).to.equal(0)
-        expect(await plushie.totalSupply()).to.equal(maxSupply)
+        expect(await rootling.tokensAvailable()).to.equal(0)
+        expect(await rootling.totalSupply()).to.equal(maxSupply)
       })
     })
 
     describe('Sad path', () => {
       it('Attempt to mint when supply reaches exactly 8 - should fail', async () => {
         // Try to whitelist and mint when supply is exhausted
-        await plushie.connect(whitelistGuardAlice).addToWhitelist([await minters[12].getAddress()])
+        await rootling.connect(whitelistGuardAlice).addToWhitelist([await minters[12].getAddress()])
 
-        await expect(plushie.connect(minters[12]).mint())
-          .to.be.revertedWithCustomError(plushie, 'PlushieNftOutOfTokens')
+        await expect(rootling.connect(minters[12]).mint())
+          .to.be.revertedWithCustomError(rootling, 'RootlingNftOutOfTokens')
           .withArgs(maxSupply)
       })
 
@@ -476,12 +475,12 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         // minters[14] has StRIF and hasn't minted (only minters[4-13] have minted)
         const failIndices = [12, 13, 14]
         const addresses = await Promise.all(failIndices.map(async i => minters[i].getAddress()))
-        await plushie.connect(whitelistGuardAlice).addToWhitelist(addresses)
+        await rootling.connect(whitelistGuardAlice).addToWhitelist(addresses)
 
         // Should fail to mint because supply is exhausted
         for (const index of failIndices) {
-          await expect(plushie.connect(minters[index]).mint())
-            .to.be.revertedWithCustomError(plushie, 'PlushieNftOutOfTokens')
+          await expect(rootling.connect(minters[index]).mint())
+            .to.be.revertedWithCustomError(rootling, 'RootlingNftOutOfTokens')
             .withArgs(maxSupply)
         }
       })
@@ -498,18 +497,18 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
 
         // approve() should work
         await expect(
-          plushie.connect(tokenOwner).approve(await approvedUser.getAddress(), tokenId),
+          rootling.connect(tokenOwner).approve(await approvedUser.getAddress(), tokenId),
         ).to.not.revert(ethers)
 
         // Check approval was set
-        expect(await plushie.getApproved(tokenId)).to.equal(await approvedUser.getAddress())
+        expect(await rootling.getApproved(tokenId)).to.equal(await approvedUser.getAddress())
 
         // But transfer should still fail
         await expect(
-          plushie
+          rootling
             .connect(approvedUser)
             .transferFrom(await tokenOwner.getAddress(), await approvedUser.getAddress(), tokenId),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftTransfersDisabled')
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftTransfersDisabled')
       })
 
       it('setApprovalForAll() works but transfers still fail', async () => {
@@ -520,33 +519,33 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
 
         // setApprovalForAll should work
         await expect(
-          plushie.connect(tokenOwner).setApprovalForAll(await operator.getAddress(), true),
+          rootling.connect(tokenOwner).setApprovalForAll(await operator.getAddress(), true),
         ).to.not.revert(ethers)
 
         // Check approval was set
-        expect(await plushie.isApprovedForAll(await tokenOwner.getAddress(), await operator.getAddress())).to
+        expect(await rootling.isApprovedForAll(await tokenOwner.getAddress(), await operator.getAddress())).to
           .be.true
 
         // But transfer should still fail
         await expect(
-          plushie
+          rootling
             .connect(operator)
             .transferFrom(await tokenOwner.getAddress(), await operator.getAddress(), tokenId),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftTransfersDisabled')
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftTransfersDisabled')
       })
 
-      it('Owner is unable to transfer Plushie with safeTransferFrom() function', async () => {
+      it('Owner is unable to transfer Rootling with safeTransferFrom() function', async () => {
         const tokenOwner = minters[4]
         const operator = minters[12]
         const tokenId = 1
-        expect(await plushie.balanceOf(await tokenOwner.getAddress())).equals(1)
+        expect(await rootling.balanceOf(await tokenOwner.getAddress())).equals(1)
         await expect(
-          plushie
+          rootling
             .connect(tokenOwner)
             [
               'safeTransferFrom(address,address,uint256)'
             ](await tokenOwner.getAddress(), await operator.getAddress(), tokenId),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftTransfersDisabled')
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftTransfersDisabled')
       })
     })
     describe('Sad path', () => {
@@ -556,10 +555,10 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         const tokenId = 1
 
         await expect(
-          plushie
+          rootling
             .connect(tokenOwner)
             .transferFrom(await tokenOwner.getAddress(), await recipient.getAddress(), tokenId),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftTransfersDisabled')
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftTransfersDisabled')
       })
 
       it('Admin cannot execute transfer on behalf of user', async () => {
@@ -568,10 +567,10 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         const tokenId = 1
 
         await expect(
-          plushie
+          rootling
             .connect(deployer)
             .transferFrom(await tokenOwner.getAddress(), await recipient.getAddress(), tokenId),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftTransfersDisabled')
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftTransfersDisabled')
       })
 
       it('Marketplace contract cannot execute transfer after approval', async () => {
@@ -582,17 +581,17 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
         const tokenId = 1
 
         // User approves marketplace
-        await plushie
+        await rootling
           .connect(tokenOwner)
           .approve(await marketplaceContract.getAddress(), tokenId)
           .then(tx => tx.wait())
 
         // Marketplace tries to transfer but fails
         await expect(
-          plushie
+          rootling
             .connect(marketplaceContract)
             .transferFrom(await tokenOwner.getAddress(), await recipient.getAddress(), tokenId),
-        ).to.be.revertedWithCustomError(plushie, 'PlushieNftTransfersDisabled')
+        ).to.be.revertedWithCustomError(rootling, 'RootlingNftTransfersDisabled')
       })
     })
   })
@@ -601,38 +600,38 @@ describe('PlushieSeries1RootstockCollective NFT', () => {
     describe('Happy path', () => {
       it('Check totalSupply(), balanceOf(), and ownerOf() accuracy after various operations', async () => {
         // Should have exactly 10 tokens (maxSupply reached)
-        const totalSupply = await plushie.totalSupply()
+        const totalSupply = await rootling.totalSupply()
         expect(totalSupply).to.equal(maxSupply)
 
         // Check specific balances
-        expect(await plushie.balanceOf(await minters[4].getAddress())).to.equal(1) // minterNum from minting tests
+        expect(await rootling.balanceOf(await minters[4].getAddress())).to.equal(1) // minterNum from minting tests
 
         // Verify ownership of first and last tokens
-        expect(await plushie.ownerOf(1)).to.equal(await minters[4].getAddress()) // First token from minting tests
-        expect(await plushie.ownerOf(maxSupply)).to.equal(await minters[11].getAddress()) // Last token from supply limit tests
+        expect(await rootling.ownerOf(1)).to.equal(await minters[4].getAddress()) // First token from minting tests
+        expect(await rootling.ownerOf(maxSupply)).to.equal(await minters[11].getAddress()) // Last token from supply limit tests
 
         // Verify tokens available is 0
-        expect(await plushie.tokensAvailable()).to.equal(0)
+        expect(await rootling.tokensAvailable()).to.equal(0)
       })
 
       it('All tokens have the same metadata IPFS CID', async () => {
         // Check tokenURI for all minted tokens (1 to 10)
         for (let tokenId = 1; tokenId <= maxSupply; tokenId++) {
-          const tokenUri = await plushie.tokenURI(tokenId)
+          const tokenUri = await rootling.tokenURI(tokenId)
           expect(tokenUri).to.equal(`ipfs://${ipfsFolderCid}`)
         }
       })
     })
     describe('Sad path', () => {
       it('tokenURI() for non-existent token reverts with clear message', async () => {
-        await expect(plushie.tokenURI(999))
-          .to.be.revertedWithCustomError(plushie, 'ERC721NonexistentToken')
+        await expect(rootling.tokenURI(999))
+          .to.be.revertedWithCustomError(rootling, 'ERC721NonexistentToken')
           .withArgs(999)
       })
 
       it('ownerOf() for non-existent token reverts', async () => {
-        await expect(plushie.ownerOf(999))
-          .to.be.revertedWithCustomError(plushie, 'ERC721NonexistentToken')
+        await expect(rootling.ownerOf(999))
+          .to.be.revertedWithCustomError(rootling, 'ERC721NonexistentToken')
           .withArgs(999)
       })
     })

--- a/test/RootlingSeries1.test.ts
+++ b/test/RootlingSeries1.test.ts
@@ -1,4 +1,4 @@
-import { rootlingSeries1Module } from '../ignition/modules/RootlingSeries1Module.js'
+import { RootlingSeries1Module } from '../ignition/modules/RootlingSeries1Module.js'
 import type {
   RootlingSeries1RootstockCollective,
   RIFToken,
@@ -15,7 +15,7 @@ const whitelistGuardRole = ethers.keccak256(ethers.toUtf8Bytes('WHITELIST_GUARD_
 const adminRole = ethers.ZeroHash
 
 async function deployRootlingNft(stRifAddress: string) {
-  const { RootlingSeries1 } = await ignition.deploy(rootlingSeries1Module, {
+  const { RootlingSeries1 } = await ignition.deploy(RootlingSeries1Module, {
     parameters: {
       RootlingSeries1: {
         stRif: stRifAddress,


### PR DESCRIPTION
# Rename Plushie NFT to Rootling Series 1 + Security Fix

## What
This PR renames the Plushie NFT contract to "Rootling Series 1" as per Foundation requirements and fixes a reentrancy vulnerability identified in security audit.

## Why
- **Foundation Requirement**: JIRA ticket DAO-1535 - Elenor from the Foundation requested the NFT name change to "RootlingSeries1RootstockCollective"
- **Security Enhancement**: Fix IS-01 reentrancy vulnerability in mint function identified in security audit v1.0.9

## Key Changes

### 🔄 **Contract Renaming (DAO-1535)**
- **Contract**: `PlushieSeries1RootstockCollective.sol` → `RootlingSeries1RootstockCollective.sol`
- **Name**: Updated to "RootlingSeries1RootstockCollective" as requested by Foundation
- **Symbol**: Updated from "PS1" to "RS1"
- **Events & Errors**: All naming updated to use "Rootling" prefix

### 🔒 **Security Fix (IS-01 Reentrancy)**
**Issue**: Potential reentrancy attack via `underlyingToken.balanceOf(caller)` call allowing bypass of mint checks

**Fix**: Moved `underlyingToken.balanceOf(caller)` call to beginning of mint function before other checks

### 📁 **Files Changed**
- **Contract**: `contracts/NFT/PlushieSeries1RootstockCollective.sol` → `RootlingSeries1RootstockCollective.sol`
- **Ignition Module**: `ignition/modules/PlushieSeries1Module.ts` → `RootlingSeries1Module.ts`
- **Test Suite**: `test/PlushieSeries1.test.ts` → `RootlingSeries1.test.ts`

## Security Impact
- **Severity**: Low → **Resolved**
- **Audit Status**: IS-01 **Resolved**

## Testing
- ✅ All tests updated and passing
- ✅ Security fix validated
- ✅ Contract compilation successful

## Compliance
- ✅ **DAO-1535**: Foundation naming requirements implemented
- ✅ **IS-01**: Security audit recommendation resolved