### PR TITLE
Rootcamp NFT security fixes

### DIFF
--- a/contracts/NFT/RootcampRootstockCollective.sol
+++ b/contracts/NFT/RootcampRootstockCollective.sol
@@ -75,6 +75,16 @@ contract RootcampRootstockCollective is
   error RootcampNftInvalidMaxSupply(uint256 newMaxSupply, uint256 currentMaxSupply);
   error RootcampNftInvalidAddress(address);
 
+  /// MODIFIERS
+
+  /// @dev Enforces the "exactly one DEFAULT_ADMIN_ROLE" invariant across access control admin functions
+  modifier enforceSingleAdmin(bytes32 role) {
+    if (role == DEFAULT_ADMIN_ROLE && getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1) {
+      revert RootcampNftAdminRoleViolation();
+    }
+    _;
+  }
+
   // INITIALIZERS
 
   /// @custom:oz-upgrades-unsafe-allow constructor
@@ -265,21 +275,23 @@ contract RootcampRootstockCollective is
   function renounceRole(
     bytes32 role,
     address callerConfirmation
-  ) public virtual override(AccessControlUpgradeable, IAccessControl) {
-    if (role == DEFAULT_ADMIN_ROLE && getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1) {
-      revert RootcampNftAdminRoleViolation();
-    }
+  ) public virtual override(AccessControlUpgradeable, IAccessControl) enforceSingleAdmin(role) {
     super.renounceRole(role, callerConfirmation);
+  }
+
+  /// @dev Prevents the last admin from renouncing his role.
+  function revokeRole(
+    bytes32 role,
+    address account
+  ) public virtual override(AccessControlUpgradeable, IAccessControl) enforceSingleAdmin(role) {
+    super.revokeRole(role, account);
   }
 
   /// @dev Prevents creating more than one default admin.
   function grantRole(
     bytes32 role,
     address account
-  ) public virtual override(AccessControlUpgradeable, IAccessControl) {
-    if (role == DEFAULT_ADMIN_ROLE && getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 1) {
-      revert RootcampNftAdminRoleViolation();
-    }
+  ) public virtual override(AccessControlUpgradeable, IAccessControl) enforceSingleAdmin(role) {
     super.grantRole(role, account);
   }
 

--- a/ignition/modules/RootcampProductionModule.ts
+++ b/ignition/modules/RootcampProductionModule.ts
@@ -1,0 +1,23 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
+import { RootcampModule } from './RootcampModule'
+
+export const RootcampProductionModule = buildModule('RootcampProduction', m => {
+  const { Rootcamp } = m.useModule(RootcampModule)
+
+  const deployer = m.getAccount(0)
+  const newAdmin = m.getParameter('newAdmin')
+  const guardRole = m.staticCall(Rootcamp, 'WHITELIST_GUARD_ROLE', [], 0, { id: 'GetGuardRole' })
+
+  const renounceGuard = m.call(Rootcamp, 'renounceRole', [guardRole, deployer], {
+    id: 'RenounceWhitelistGuard',
+  })
+
+  m.call(Rootcamp, 'transferDefaultAdminRole', [newAdmin], {
+    id: 'TransferAdmin',
+    after: [renounceGuard],
+  })
+
+  return { Rootcamp }
+})
+
+export default RootcampProductionModule

--- a/params/Rootcamp/mainnet.json
+++ b/params/Rootcamp/mainnet.json
@@ -12,5 +12,8 @@
       "0xfEb163F701656aEA55035e460E755241C17eD35d",
       "0x9145e0fEABDE3eE7A2f8b0a82983c129BAbc2191"
     ]
+  },
+  "RootcampProduction": {
+    "newAdmin": "0x3e4a679E27c2fF3381d1140D41eEFB83c4a9D1Db"
   }
 }

--- a/test/Rootcamp.test.ts
+++ b/test/Rootcamp.test.ts
@@ -163,6 +163,16 @@ describe('RootcampRootstockCollective NFT', () => {
           rootcamp.renounceRole(adminRole, await deployer.getAddress()),
         ).to.be.revertedWithCustomError(rootcamp, 'RootcampNftAdminRoleViolation')
       })
+      it('Default admin cannot revoke his own role when he is the last admin', async () => {
+        await expect(
+          rootcamp.revokeRole(adminRole, await deployer.getAddress()),
+        ).to.be.revertedWithCustomError(rootcamp, 'RootcampNftAdminRoleViolation')
+      })
+      it('Stranger cannot revoke admin role', async () => {
+        await expect(
+          rootcamp.connect(stranger).revokeRole(adminRole, await deployer.getAddress()),
+        ).to.be.revertedWithCustomError(rootcamp, 'RootcampNftAdminRoleViolation')
+      })
       it('Cannot grant second admin role - only one admin allowed', async () => {
         await expect(
           rootcamp.grantRole(adminRole, await stranger.getAddress()),


### PR DESCRIPTION
## Tickets
- [DAO-2191](https://rsklabs.atlassian.net/browse/DAO-2191) — revokeRole bypass allows the last default admin to remove themselves, permanently bricking the contract
- [DAO-2089](https://rsklabs.atlassian.net/browse/DAO-2089) — Post release transfer ownership of Rootcamp SC to appropriate multisig owner

## Summary
- Close the `revokeRole` bypass that allowed the sole admin to brick the contract by introducing an `enforceSingleAdmin` modifier applied to `grantRole`, `revokeRole`, and `renounceRole`
- Add a production deployment module (`RootcampProductionModule`) that transfers admin role to a multisig and renounces the deployer's whitelist guard role

## Screenshots
N/A — smart contract changes only

## Test Plan
- Run `npx hardhat test test/Rootcamp.test.ts` — verify `revokeRole` revert tests pass
- Deploy with `RootcampProductionModule` on testnet — verify admin is transferred and deployer loses both roles
- Confirm `RootcampModule` (used in tests) is unaffected