### PR TITLE
fix(treasury): reject zero-address owner and guardian in constructor

### DIFF
--- a/contracts/TreasuryRootstockCollective.sol
+++ b/contracts/TreasuryRootstockCollective.sol
@@ -18,6 +18,8 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
 
   error InvalidGuardian(address account);
 
+  error InvalidAdmin(address account);
+
   mapping(address => bool) public whitelist;
   bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
   bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
@@ -28,6 +30,8 @@ contract TreasuryRootstockCollective is AccessControl, ReentrancyGuard, ITreasur
    * @param guardian Guardian
    */
   constructor(address initialOwner, address guardian) {
+    if (initialOwner == address(0)) revert InvalidAdmin(initialOwner);
+    if (guardian == address(0)) revert InvalidGuardian(guardian);
     _grantRole(DEFAULT_ADMIN_ROLE, initialOwner);
     _grantRole(GUARDIAN_ROLE, initialOwner);
     _grantRole(GUARDIAN_ROLE, guardian);

--- a/test/Treasury.test.ts
+++ b/test/Treasury.test.ts
@@ -240,4 +240,28 @@ describe('Treasury Contract', () => {
         .withArgs(beneficiary.address, GuardianRole)
     })
   })
+
+  describe('Constructor zero-address validation', () => {
+    it('Reverts when initialOwner is the zero address', async () => {
+      const Treasury = await ethers.getContractFactory('TreasuryRootstockCollective')
+      await expect(Treasury.deploy(ethers.ZeroAddress, guardian.address))
+        .to.be.revertedWithCustomError(Treasury, 'InvalidAdmin')
+        .withArgs(ethers.ZeroAddress)
+    })
+
+    it('Reverts when guardian is the zero address', async () => {
+      const Treasury = await ethers.getContractFactory('TreasuryRootstockCollective')
+      await expect(Treasury.deploy(owner.address, ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(Treasury, 'InvalidGuardian')
+        .withArgs(ethers.ZeroAddress)
+    })
+
+    it('Deploys successfully with non-zero owner and guardian', async () => {
+      const Treasury = await ethers.getContractFactory('TreasuryRootstockCollective')
+      const newTreasury = await Treasury.deploy(owner.address, guardian.address)
+      await newTreasury.waitForDeployment()
+      expect(await newTreasury.hasRole(await newTreasury.DEFAULT_ADMIN_ROLE(), owner.address)).to.be.true
+      expect(await newTreasury.hasRole(await newTreasury.GUARDIAN_ROLE(), guardian.address)).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
Fixing error reported on Certik, adding `error InvalidAdmin`  to the constructor validation in case of Zero address used.

`TreasuryRootstockCollective grants privileged roles directly from constructor inputs without rejecting address(0). If initialOwner == address(0), the zero address receives DEFAULT_ADMIN_ROLE, leaving no usable account able to grant EXECUTOR_ROLE or repair role assignments. If guardian == address(0), the zero address receives GUARDIAN_ROLE. With both inputs set to zero, normal and emergency withdrawal authority can be unavailable from deployment.`