### PR TITLE
Fix timelock initialize

### DIFF
--- a/contracts/DaoTimelockUpgradableRootstockCollective.sol
+++ b/contracts/DaoTimelockUpgradableRootstockCollective.sol
@@ -4,12 +4,17 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/governance/TimelockControllerUpgradeable.sol";
 
 contract DaoTimelockUpgradableRootstockCollective is UUPSUpgradeable, TimelockControllerUpgradeable {
+  error InvalidTimelockBootstrap();
+
   function initialize(
     uint256 minDelay,
     address[] memory proposers,
     address[] memory executors,
     address admin
   ) public initializer {
+    if (admin == address(0) && (proposers.length == 0 || executors.length == 0)) {
+      revert InvalidTimelockBootstrap();
+    }
     __UUPSUpgradeable_init();
     __AccessControl_init();
     __TimelockController_init(minDelay, proposers, executors, admin);

--- a/test/DaoTimelock.test.ts
+++ b/test/DaoTimelock.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { DaoTimelockUpgradableRootstockCollective } from '../typechain-types'
+
+describe('DaoTimelockUpgradableRootstockCollective initialization guard', () => {
+  const minDelay = 900
+  const zeroAddress = ethers.ZeroAddress
+
+  /**
+   * Deploys the timelock implementation behind an ERC1967 proxy, forwarding the
+   * given roles to `initialize`. Returns the proxy typed as the timelock.
+   */
+  const deployTimelock = async (proposers: string[], executors: string[], admin: string) => {
+    const Timelock = await ethers.getContractFactory('DaoTimelockUpgradableRootstockCollective')
+    const implementation = await Timelock.deploy()
+    await implementation.waitForDeployment()
+
+    const initData = implementation.interface.encodeFunctionData('initialize', [
+      minDelay,
+      proposers,
+      executors,
+      admin,
+    ])
+
+    const Proxy = await ethers.getContractFactory('ERC1967Proxy')
+    const proxy = await Proxy.deploy(await implementation.getAddress(), initData)
+    await proxy.waitForDeployment()
+
+    return Timelock.attach(await proxy.getAddress()) as unknown as DaoTimelockUpgradableRootstockCollective
+  }
+
+  it('reverts when admin is zero and both role arrays are empty', async () => {
+    const Timelock = await ethers.getContractFactory('DaoTimelockUpgradableRootstockCollective')
+    await expect(deployTimelock([], [], zeroAddress)).to.be.revertedWithCustomError(
+      Timelock,
+      'InvalidTimelockBootstrap',
+    )
+  })
+
+  it('reverts when admin is zero and only executors are provided', async () => {
+    const [operator] = await ethers.getSigners()
+    const Timelock = await ethers.getContractFactory('DaoTimelockUpgradableRootstockCollective')
+    await expect(deployTimelock([], [operator.address], zeroAddress)).to.be.revertedWithCustomError(
+      Timelock,
+      'InvalidTimelockBootstrap',
+    )
+  })
+
+  it('reverts when admin is zero and only proposers are provided', async () => {
+    const [operator] = await ethers.getSigners()
+    const Timelock = await ethers.getContractFactory('DaoTimelockUpgradableRootstockCollective')
+    await expect(deployTimelock([operator.address], [], zeroAddress)).to.be.revertedWithCustomError(
+      Timelock,
+      'InvalidTimelockBootstrap',
+    )
+  })
+
+  it('succeeds when a non-zero admin is provided with empty role arrays', async () => {
+    const [admin] = await ethers.getSigners()
+    const timelock = await deployTimelock([], [], admin.address)
+    const adminRole = await timelock.DEFAULT_ADMIN_ROLE()
+    expect(await timelock.hasRole(adminRole, admin.address)).to.equal(true)
+  })
+
+  it('succeeds when admin is zero but proposer and executor roles are assigned', async () => {
+    const [proposer, executor] = await ethers.getSigners()
+    const timelock = await deployTimelock([proposer.address], [executor.address], zeroAddress)
+    const proposerRole = await timelock.PROPOSER_ROLE()
+    const executorRole = await timelock.EXECUTOR_ROLE()
+    expect(await timelock.hasRole(proposerRole, proposer.address)).to.equal(true)
+    expect(await timelock.hasRole(executorRole, executor.address)).to.equal(true)
+  })
+})


### PR DESCRIPTION
Fixing error reported on Certik, adding error error InvalidTimelockBootstrap to the initialize function in case of Zero address used. Hygiene fix proposed.

`DaoTimelockUpgradableRootstockCollective.initialize() forwards admin, proposers, and executors directly into OpenZeppelin's timelock initializer. If the proxy is initialized with admin == address(0) and empty proposer and executor arrays, initialization succeeds but no external account can administer, propose, execute, or upgrade the timelock. The timelock holds its own DEFAULT_ADMIN_ROLE, but it cannot schedule or execute the self-call needed to recover because no proposer or executor exists.`